### PR TITLE
feat: Unit Conversion Fail-Safe — 未知單位拒絕猜測機制

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,13 @@
 - **更新 test-traceability 報告與 regulatory-issue-mapping**
 
 ### 功能改進 (Features)
+- **Unit Conversion Fail-Safe — 未知/缺失單位拒絕猜測機制** — 當 EHR 回傳的檢驗值單位無法辨認（如 `mg/L` 代替 `g/dL`）或完全缺失時：
+  - **後端**：`UnitConversionService.get_value_with_status()` 新增 5 種狀態碼（`ok`/`no_data`/`no_value`/`missing_unit`/`unknown_unit`），區分「FHIR 無資料」vs「有資料但單位無法轉換」
+  - **Calculator**：`extract_inputs()` 追蹤 `unit_issues[]`，`_check_unit_issue_warnings()` 產生 `unrecognized_unit` 類型警告（severity=high），明確告知醫師原始值、未知單位、預期單位
+  - **前端**：`main.html` 新增 `#unit-warning` alert-danger 區塊，`main.js` 新增 `displayUnitWarnings()` 函式
+  - **安全策略**：系統**拒絕猜測單位**，將該參數排除於計分之外（score=0），並在 UI 標示「Not available」+ 明確原因
+  - **30 項新增測試**（`tests/test_unit_failsafe.py`）：狀態碼驗證、追蹤機制、警告產生、邊界案例、向下相容
+  - 依 ISO 14971 RISK-001 設計：猜錯單位可能造成 10 倍量級誤差，直接影響風險分類
 - **Data Quality Warning — 數值截斷警告機制** — 當 EHR 傳入的檢驗值超出臨床預期範圍（如血紅素因單位錯誤被放大 10 倍），系統不再默默截斷，而是：
   - **後端**：`PreciseHBRCalculator._check_truncation_warnings()` 偵測 Age/Hb/eGFR/WBC 四項參數的截斷情況，產生結構化警告（含原始值、截斷值、方向、預期範圍、建議訊息）
   - **元件顯示**：截斷的參數在 component display 中顯示 `(capped to X)`，並附帶 `is_truncated` / `effective_value` 標記

--- a/services/precise_hbr_calculator.py
+++ b/services/precise_hbr_calculator.py
@@ -128,9 +128,10 @@ class PreciseHBRCalculator:
             'arc_hbr_count': 0,
             'missing_fields': [],
             'empty_fhir_resources': [],  # Track empty FHIR resource types
+            'unit_issues': [],           # Track unrecognized/missing unit problems
             'metadata': {}
         }
-        
+
         # 1. Age
         age = demographics.get('age')
         if age is not None:
@@ -138,59 +139,99 @@ class PreciseHBRCalculator:
             inputs['metadata']['age_effective'] = max(limits['min_age'], min(limits['max_age'], age))
         else:
             inputs['missing_fields'].append('Age')
-            
+
         # 2. Hemoglobin
         hemoglobin_list = raw_data.get('HEMOGLOBIN', [])
         if hemoglobin_list:
             hb_obs = hemoglobin_list[0]
-            hb_val = unit_converter.get_value_from_observation(hb_obs, unit_converter.TARGET_UNITS['HEMOGLOBIN'])
-            if hb_val is not None:
-                inputs['hb'] = hb_val
-                inputs['metadata']['hb_effective'] = max(limits['min_hb'], min(limits['max_hb'], hb_val))
+            hb_result = unit_converter.get_value_with_status(hb_obs, unit_converter.TARGET_UNITS['HEMOGLOBIN'])
+            if hb_result['value'] is not None:
+                inputs['hb'] = hb_result['value']
+                inputs['metadata']['hb_effective'] = max(limits['min_hb'], min(limits['max_hb'], hb_result['value']))
                 inputs['metadata']['hb_date'] = hb_obs.get('effectiveDateTime', 'N/A')
+            elif hb_result['status'] in (unit_converter.STATUS_UNKNOWN_UNIT, unit_converter.STATUS_MISSING_UNIT):
+                inputs['unit_issues'].append({
+                    'parameter': 'Hemoglobin',
+                    'status': hb_result['status'],
+                    'raw_value': hb_result['raw_value'],
+                    'source_unit': hb_result['source_unit'],
+                    'target_unit': hb_result['target_unit'],
+                })
+                inputs['missing_fields'].append('Hemoglobin')
             else:
                 inputs['missing_fields'].append('Hemoglobin')
         else:
             inputs['missing_fields'].append('Hemoglobin')
-            
+
         # 3. eGFR
         egfr_val = None
         egfr_source = ""
+        egfr_unit_issue = None
         egfr_list = raw_data.get('EGFR', [])
         if egfr_list:
             egfr_obs = egfr_list[0]
-            egfr_val = unit_converter.get_value_from_observation(egfr_obs, unit_converter.TARGET_UNITS['EGFR'])
-            egfr_source = "Direct eGFR"
-            inputs['metadata']['egfr_date'] = egfr_obs.get('effectiveDateTime', 'N/A')
-            
+            egfr_result = unit_converter.get_value_with_status(egfr_obs, unit_converter.TARGET_UNITS['EGFR'])
+            if egfr_result['value'] is not None:
+                egfr_val = egfr_result['value']
+                egfr_source = "Direct eGFR"
+                inputs['metadata']['egfr_date'] = egfr_obs.get('effectiveDateTime', 'N/A')
+            elif egfr_result['status'] in (unit_converter.STATUS_UNKNOWN_UNIT, unit_converter.STATUS_MISSING_UNIT):
+                egfr_unit_issue = {
+                    'parameter': 'eGFR',
+                    'status': egfr_result['status'],
+                    'raw_value': egfr_result['raw_value'],
+                    'source_unit': egfr_result['source_unit'],
+                    'target_unit': egfr_result['target_unit'],
+                }
+
         if egfr_val is None:
             creatinine_list = raw_data.get('CREATININE', [])
             if creatinine_list and inputs['age'] is not None and demographics.get('gender'):
                 creatinine_obs = creatinine_list[0]
-                creatinine_val = unit_converter.get_value_from_observation(creatinine_obs, unit_converter.TARGET_UNITS['CREATININE'])
-                if creatinine_val:
-                    calc_egfr, reason = unit_converter.calculate_egfr(creatinine_val, inputs['age'], demographics['gender'])
+                cr_result = unit_converter.get_value_with_status(creatinine_obs, unit_converter.TARGET_UNITS['CREATININE'])
+                if cr_result['value'] is not None:
+                    calc_egfr, reason = unit_converter.calculate_egfr(cr_result['value'], inputs['age'], demographics['gender'])
                     if calc_egfr:
                         egfr_val = calc_egfr
                         egfr_source = reason
+                        egfr_unit_issue = None  # Creatinine fallback succeeded
                         inputs['metadata']['egfr_date'] = creatinine_obs.get('effectiveDateTime', 'N/A')
-        
+                elif cr_result['status'] in (unit_converter.STATUS_UNKNOWN_UNIT, unit_converter.STATUS_MISSING_UNIT) and not egfr_unit_issue:
+                    egfr_unit_issue = {
+                        'parameter': 'Creatinine (for eGFR calculation)',
+                        'status': cr_result['status'],
+                        'raw_value': cr_result['raw_value'],
+                        'source_unit': cr_result['source_unit'],
+                        'target_unit': cr_result['target_unit'],
+                    }
+
         if egfr_val is not None:
             inputs['egfr'] = egfr_val
             inputs['metadata']['egfr_effective'] = max(limits['min_egfr'], min(limits['max_egfr'], egfr_val))
             inputs['metadata']['egfr_source'] = egfr_source
         else:
             inputs['missing_fields'].append('eGFR')
+            if egfr_unit_issue:
+                inputs['unit_issues'].append(egfr_unit_issue)
 
         # 4. WBC
         wbc_list = raw_data.get('WBC', [])
         if wbc_list:
             wbc_obs = wbc_list[0]
-            wbc_val = unit_converter.get_value_from_observation(wbc_obs, unit_converter.TARGET_UNITS['WBC'])
-            if wbc_val is not None:
-                inputs['wbc'] = wbc_val
-                inputs['metadata']['wbc_effective'] = max(limits['min_wbc'], min(limits['max_wbc'], wbc_val))
+            wbc_result = unit_converter.get_value_with_status(wbc_obs, unit_converter.TARGET_UNITS['WBC'])
+            if wbc_result['value'] is not None:
+                inputs['wbc'] = wbc_result['value']
+                inputs['metadata']['wbc_effective'] = max(limits['min_wbc'], min(limits['max_wbc'], wbc_result['value']))
                 inputs['metadata']['wbc_date'] = wbc_obs.get('effectiveDateTime', 'N/A')
+            elif wbc_result['status'] in (unit_converter.STATUS_UNKNOWN_UNIT, unit_converter.STATUS_MISSING_UNIT):
+                inputs['unit_issues'].append({
+                    'parameter': 'WBC',
+                    'status': wbc_result['status'],
+                    'raw_value': wbc_result['raw_value'],
+                    'source_unit': wbc_result['source_unit'],
+                    'target_unit': wbc_result['target_unit'],
+                })
+                inputs['missing_fields'].append('WBC')
             else:
                 inputs['missing_fields'].append('WBC')
         else:
@@ -287,6 +328,57 @@ class PreciseHBRCalculator:
                         f'or data entry issue in the EHR.'
                     ),
                 })
+
+        return warnings
+
+    @classmethod
+    def _check_unit_issue_warnings(cls, inputs):
+        """
+        Generate high-severity warnings when lab values were present in the EHR
+        but could not be used because the unit was unrecognized or missing.
+
+        This is a Fail-safe mechanism for Class C medical devices: the system
+        refuses to guess and explicitly alerts the clinician, rather than
+        silently treating the value as "missing data".
+        """
+        warnings = []
+        for issue in inputs.get('unit_issues', []):
+            status = issue['status']
+            param = issue['parameter']
+            raw_val = issue['raw_value']
+            source_unit = issue.get('source_unit')
+            target_unit = issue['target_unit']
+
+            if status == unit_converter.STATUS_MISSING_UNIT:
+                message = (
+                    f'{param} value {raw_val} was received from the EHR '
+                    f'without a unit. The expected unit is {target_unit}. '
+                    f'The system cannot safely assume the unit and has '
+                    f'excluded this value from the score calculation. '
+                    f'Please verify the value and unit in the EHR, then '
+                    f'use the manual override if appropriate.'
+                )
+            else:  # STATUS_UNKNOWN_UNIT
+                message = (
+                    f'{param} value {raw_val} was received with an '
+                    f'unrecognized unit "{source_unit}". '
+                    f'The expected unit is {target_unit}. '
+                    f'The system cannot safely convert this value and has '
+                    f'excluded it from the score calculation. '
+                    f'Please verify the value and unit in the EHR, then '
+                    f'use the manual override if appropriate.'
+                )
+
+            warnings.append({
+                'type': 'unrecognized_unit',
+                'severity': 'high',
+                'parameter': param,
+                'raw_value': raw_val,
+                'source_unit': source_unit,
+                'target_unit': target_unit,
+                'status': status,
+                'message': message,
+            })
 
         return warnings
 
@@ -612,6 +704,10 @@ class PreciseHBRCalculator:
         # Build data quality warnings for truncated values
         truncation_warnings = cls._check_truncation_warnings(inputs)
         data_warnings.extend(truncation_warnings)
+
+        # Build warnings for unrecognized/missing units (Fail-safe for Class C)
+        unit_issue_warnings = cls._check_unit_issue_warnings(inputs)
+        data_warnings.extend(unit_issue_warnings)
 
         logging.info(f"PRECISE-HBR calculation complete: {total_score}")
         if data_warnings:

--- a/services/unit_conversion_service.py
+++ b/services/unit_conversion_service.py
@@ -85,30 +85,72 @@ class UnitConversionService:
         }
     }
     
+    # Status constants for get_value_with_status
+    STATUS_OK = 'ok'
+    STATUS_NO_DATA = 'no_data'
+    STATUS_NO_VALUE = 'no_value'
+    STATUS_MISSING_UNIT = 'missing_unit'
+    STATUS_UNKNOWN_UNIT = 'unknown_unit'
+
     @classmethod
     def get_value_from_observation(cls, obs, unit_system):
         """
         Safely extracts a numeric value from an Observation resource, handling unit conversions.
         Returns the numeric value in the target unit, or None if conversion is not possible.
         """
+        result = cls.get_value_with_status(obs, unit_system)
+        return result['value']
+
+    @classmethod
+    def get_value_with_status(cls, obs, unit_system):
+        """
+        Extracts a numeric value with detailed status about the conversion outcome.
+
+        Returns:
+            dict with keys:
+                - value: converted numeric value, or None
+                - status: STATUS_OK | STATUS_NO_DATA | STATUS_NO_VALUE |
+                          STATUS_MISSING_UNIT | STATUS_UNKNOWN_UNIT
+                - source_unit: the raw unit string from the observation (or None)
+                - target_unit: the expected canonical unit
+                - raw_value: the original numeric value before conversion (or None)
+        """
+        target_unit = unit_system['unit'].lower()
+        no_data = {'value': None, 'status': cls.STATUS_NO_DATA,
+                   'source_unit': None, 'target_unit': target_unit, 'raw_value': None}
+
         if not obs or not isinstance(obs, dict):
-            return None
+            return no_data
 
         value_quantity = obs.get('valueQuantity')
         if not value_quantity:
-            return None
+            return no_data
 
         value = value_quantity.get('value')
         if value is None or not isinstance(value, (int, float)):
-            return None
-        
+            return {'value': None, 'status': cls.STATUS_NO_VALUE,
+                    'source_unit': value_quantity.get('unit'),
+                    'target_unit': target_unit, 'raw_value': None}
+
         # Normalize both units to lowercase for consistent comparison
-        source_unit = value_quantity.get('unit', '').lower().strip()
-        target_unit = unit_system['unit'].lower()
-        
+        raw_unit = value_quantity.get('unit')
+        source_unit = (raw_unit or '').lower().strip()
+
+        # Missing unit — value present but no unit specified
+        if not source_unit:
+            logging.warning(
+                f"Observation has numeric value {value} but no unit specified. "
+                f"Expected: '{target_unit}'. Refusing to guess — treating as unusable."
+            )
+            return {'value': None, 'status': cls.STATUS_MISSING_UNIT,
+                    'source_unit': raw_unit, 'target_unit': target_unit,
+                    'raw_value': value}
+
         # 1. Direct match (case-insensitive)
         if source_unit == target_unit:
-            return value
+            return {'value': value, 'status': cls.STATUS_OK,
+                    'source_unit': raw_unit, 'target_unit': target_unit,
+                    'raw_value': value}
 
         # 2. Attempt conversion using factors
         conversion_factors = unit_system.get('factors', {})
@@ -116,14 +158,19 @@ class UnitConversionService:
             conversion_factor = conversion_factors[source_unit]
             converted_value = value * conversion_factor
             logging.info(f"Converted {value} {source_unit} to {converted_value:.2f} {target_unit}")
-            return converted_value
+            return {'value': converted_value, 'status': cls.STATUS_OK,
+                    'source_unit': raw_unit, 'target_unit': target_unit,
+                    'raw_value': value}
 
-        # 3. If no conversion is possible, log a warning and return None
+        # 3. Unknown unit — value and unit present but no conversion rule
         logging.warning(
             f"Unit mismatch and no conversion rule found for Observation. "
-            f"Received: '{source_unit}', Expected: '{target_unit}'. Cannot proceed with this value."
+            f"Received: '{source_unit}', Expected: '{target_unit}'. "
+            f"Raw value: {value}. Refusing to guess — treating as unusable."
         )
-        return None
+        return {'value': None, 'status': cls.STATUS_UNKNOWN_UNIT,
+                'source_unit': raw_unit, 'target_unit': target_unit,
+                'raw_value': value}
     
     @classmethod
     def validate_egfr_inputs(cls, cr_val, age, gender):

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -822,6 +822,9 @@
 
             // Display truncation warnings (data quality alerts)
             displayTruncationWarnings();
+
+            // Display unrecognized unit warnings (fail-safe alerts)
+            displayUnitWarnings();
         } else {
             const tr = document.createElement('tr');
             const td = document.createElement('td');
@@ -1048,6 +1051,38 @@
             clearElement(warningList);
 
             truncationWarnings.forEach(warning => {
+                const li = document.createElement('li');
+                const strong = document.createElement('strong');
+                strong.textContent = (warning.parameter || 'Unknown') + ': ';
+                li.appendChild(strong);
+                li.appendChild(document.createTextNode(warning.message || ''));
+                warningList.appendChild(li);
+            });
+
+            warningDiv.classList.remove('d-none');
+        } else {
+            warningDiv.classList.add('d-none');
+        }
+    }
+
+    /**
+     * Display data quality warnings for values with unrecognized or missing units.
+     * These values were excluded from score calculation (fail-safe for Class C).
+     */
+    function displayUnitWarnings() {
+        const warningDiv = document.getElementById('unit-warning');
+        const warningList = document.getElementById('unit-warning-list');
+
+        if (!warningDiv || !warningList) return;
+
+        const unitWarnings = (dataWarnings || []).filter(
+            w => w.type === 'unrecognized_unit'
+        );
+
+        if (unitWarnings.length > 0) {
+            clearElement(warningList);
+
+            unitWarnings.forEach(warning => {
                 const li = document.createElement('li');
                 const strong = document.createElement('strong');
                 strong.textContent = (warning.parameter || 'Unknown') + ': ';

--- a/templates/main.html
+++ b/templates/main.html
@@ -247,6 +247,30 @@
             </div>
         </div>
 
+        <!-- Data Quality Warning (Unrecognized / Missing Units) -->
+        <div id="unit-warning" class="alert alert-danger mb-4 d-none" role="alert" aria-live="assertive">
+            <div class="d-flex align-items-start">
+                <i class="fas fa-exclamation-triangle me-3 mt-1" style="font-size:1.5rem" aria-hidden="true"></i>
+                <div class="flex-grow-1">
+                    <h5 class="alert-heading mb-2">
+                        <strong>Data Quality Alert - Unrecognized Unit(s)</strong>
+                    </h5>
+                    <p class="mb-2">
+                        One or more lab values were received with an <strong>unrecognized or missing unit</strong>.
+                        These values have been <strong>excluded from the score calculation</strong> rather than
+                        guessing the unit. The affected parameters are shown as "Not available" above.
+                    </p>
+                    <ul id="unit-warning-list" class="mb-2">
+                        <!-- Unit warning items inserted by JavaScript -->
+                    </ul>
+                    <p class="mb-0">
+                        <i class="fas fa-user-md"></i>
+                        <strong>Please verify the values and units in the EHR. Use manual override if appropriate.</strong>
+                    </p>
+                </div>
+            </div>
+        </div>
+
         <!-- Score Breakdown -->
         <div class="card shadow-sm mb-4">
             <div class="card-header">

--- a/tests/test_unit_failsafe.py
+++ b/tests/test_unit_failsafe.py
@@ -1,0 +1,311 @@
+"""
+Unit Conversion Fail-Safe Tests
+
+Verifies that when EHR observations contain unrecognized or missing units,
+the system refuses to guess and generates explicit warnings instead of
+silently treating the value as "missing data".
+
+IEC 62304 §5.5 — Software Unit Verification
+ISO 14971 — Risk Control: RISK-001 (Score Calculation Integrity)
+
+Class C safety rationale: guessing units could cause a 10x magnitude error
+(e.g., g/L vs g/dL for Hemoglobin), leading to incorrect risk classification.
+"""
+
+import pytest
+from services.unit_conversion_service import UnitConversionService, unit_converter
+from services.precise_hbr_calculator import PreciseHBRCalculator
+
+
+def _make_demographics(age=65, gender='male'):
+    return {'age': age, 'gender': gender, 'name': 'Test'}
+
+
+def _make_raw_data(**overrides):
+    """Build minimal raw_data dict. Pass FHIR observation lists directly."""
+    data = {
+        'conditions': [],
+        'med_requests': [],
+        'HEMOGLOBIN': [],
+        'EGFR': [],
+        'WBC': [],
+        'CREATININE': [],
+    }
+    data.update(overrides)
+    return data
+
+
+# =========================================================================
+# UnitConversionService.get_value_with_status — Status Differentiation
+# =========================================================================
+
+@pytest.mark.requirement("SRS-001")
+@pytest.mark.risk("RISK-001")
+@pytest.mark.design("SDS-001")
+class TestGetValueWithStatus:
+    """Verify get_value_with_status returns correct status codes."""
+
+    def test_ok_status_direct_match(self):
+        """Known unit with direct match → STATUS_OK."""
+        obs = {'valueQuantity': {'value': 12.0, 'unit': 'g/dL'}}
+        result = unit_converter.get_value_with_status(obs, unit_converter.TARGET_UNITS['HEMOGLOBIN'])
+        assert result['status'] == UnitConversionService.STATUS_OK
+        assert result['value'] == 12.0
+
+    def test_ok_status_after_conversion(self):
+        """Known unit requiring conversion → STATUS_OK with converted value."""
+        obs = {'valueQuantity': {'value': 120.0, 'unit': 'g/L'}}
+        result = unit_converter.get_value_with_status(obs, unit_converter.TARGET_UNITS['HEMOGLOBIN'])
+        assert result['status'] == UnitConversionService.STATUS_OK
+        assert result['value'] == pytest.approx(12.0, abs=0.01)
+
+    def test_unknown_unit_status(self):
+        """Unrecognized unit → STATUS_UNKNOWN_UNIT, value=None, raw_value preserved."""
+        obs = {'valueQuantity': {'value': 70.0, 'unit': 'mg/L'}}
+        result = unit_converter.get_value_with_status(obs, unit_converter.TARGET_UNITS['HEMOGLOBIN'])
+        assert result['status'] == UnitConversionService.STATUS_UNKNOWN_UNIT
+        assert result['value'] is None
+        assert result['raw_value'] == 70.0
+        assert result['source_unit'] == 'mg/L'
+
+    def test_missing_unit_status(self):
+        """No unit field → STATUS_MISSING_UNIT, value=None, raw_value preserved."""
+        obs = {'valueQuantity': {'value': 12.0}}
+        result = unit_converter.get_value_with_status(obs, unit_converter.TARGET_UNITS['HEMOGLOBIN'])
+        assert result['status'] == UnitConversionService.STATUS_MISSING_UNIT
+        assert result['value'] is None
+        assert result['raw_value'] == 12.0
+
+    def test_empty_string_unit_is_missing(self):
+        """Empty string unit → STATUS_MISSING_UNIT."""
+        obs = {'valueQuantity': {'value': 12.0, 'unit': ''}}
+        result = unit_converter.get_value_with_status(obs, unit_converter.TARGET_UNITS['HEMOGLOBIN'])
+        assert result['status'] == UnitConversionService.STATUS_MISSING_UNIT
+        assert result['value'] is None
+        assert result['raw_value'] == 12.0
+
+    def test_whitespace_only_unit_is_missing(self):
+        """Whitespace-only unit → STATUS_MISSING_UNIT."""
+        obs = {'valueQuantity': {'value': 12.0, 'unit': '   '}}
+        result = unit_converter.get_value_with_status(obs, unit_converter.TARGET_UNITS['HEMOGLOBIN'])
+        assert result['status'] == UnitConversionService.STATUS_MISSING_UNIT
+
+    def test_no_data_status_none_obs(self):
+        """None observation → STATUS_NO_DATA."""
+        result = unit_converter.get_value_with_status(None, unit_converter.TARGET_UNITS['HEMOGLOBIN'])
+        assert result['status'] == UnitConversionService.STATUS_NO_DATA
+
+    def test_no_data_status_empty_dict(self):
+        """Empty dict → STATUS_NO_DATA."""
+        result = unit_converter.get_value_with_status({}, unit_converter.TARGET_UNITS['HEMOGLOBIN'])
+        assert result['status'] == UnitConversionService.STATUS_NO_DATA
+
+    def test_no_value_status(self):
+        """valueQuantity present but no numeric value → STATUS_NO_VALUE."""
+        obs = {'valueQuantity': {'unit': 'g/dL'}}
+        result = unit_converter.get_value_with_status(obs, unit_converter.TARGET_UNITS['HEMOGLOBIN'])
+        assert result['status'] == UnitConversionService.STATUS_NO_VALUE
+
+    def test_backward_compat_get_value_from_observation(self):
+        """get_value_from_observation still returns None for unknown unit."""
+        obs = {'valueQuantity': {'value': 70.0, 'unit': 'mg/L'}}
+        val = unit_converter.get_value_from_observation(obs, unit_converter.TARGET_UNITS['HEMOGLOBIN'])
+        assert val is None
+
+    def test_backward_compat_get_value_from_observation_ok(self):
+        """get_value_from_observation still returns value for known unit."""
+        obs = {'valueQuantity': {'value': 12.0, 'unit': 'g/dL'}}
+        val = unit_converter.get_value_from_observation(obs, unit_converter.TARGET_UNITS['HEMOGLOBIN'])
+        assert val == 12.0
+
+
+# =========================================================================
+# Calculator — Unit Issue Tracking
+# =========================================================================
+
+@pytest.mark.requirement("SRS-001")
+@pytest.mark.risk("RISK-001")
+@pytest.mark.design("SDS-001")
+class TestUnitIssueTracking:
+    """Verify extract_inputs tracks unit issues separately from missing data."""
+
+    def test_unknown_hb_unit_tracked(self):
+        """Hb with unknown unit → in both missing_fields AND unit_issues."""
+        raw = _make_raw_data(HEMOGLOBIN=[{'valueQuantity': {'value': 70, 'unit': 'mg/L'}}])
+        inputs = PreciseHBRCalculator.extract_inputs(raw, _make_demographics())
+        assert 'Hemoglobin' in inputs['missing_fields']
+        assert len(inputs['unit_issues']) == 1
+        assert inputs['unit_issues'][0]['parameter'] == 'Hemoglobin'
+        assert inputs['unit_issues'][0]['status'] == UnitConversionService.STATUS_UNKNOWN_UNIT
+        assert inputs['unit_issues'][0]['raw_value'] == 70
+        assert inputs['unit_issues'][0]['source_unit'] == 'mg/L'
+
+    def test_missing_hb_unit_tracked(self):
+        """Hb with no unit → in both missing_fields AND unit_issues."""
+        raw = _make_raw_data(HEMOGLOBIN=[{'valueQuantity': {'value': 12.0}}])
+        inputs = PreciseHBRCalculator.extract_inputs(raw, _make_demographics())
+        assert 'Hemoglobin' in inputs['missing_fields']
+        assert len(inputs['unit_issues']) >= 1
+        hb_issue = [i for i in inputs['unit_issues'] if i['parameter'] == 'Hemoglobin'][0]
+        assert hb_issue['status'] == UnitConversionService.STATUS_MISSING_UNIT
+
+    def test_no_fhir_data_no_unit_issue(self):
+        """Hb not present at all → missing_fields but NO unit_issues."""
+        raw = _make_raw_data()
+        inputs = PreciseHBRCalculator.extract_inputs(raw, _make_demographics())
+        assert 'Hemoglobin' in inputs['missing_fields']
+        hb_issues = [i for i in inputs['unit_issues'] if i['parameter'] == 'Hemoglobin']
+        assert len(hb_issues) == 0
+
+    def test_unknown_wbc_unit_tracked(self):
+        """WBC with unknown unit → tracked."""
+        raw = _make_raw_data(WBC=[{'valueQuantity': {'value': 8.5, 'unit': 'cells/uL'}}])
+        inputs = PreciseHBRCalculator.extract_inputs(raw, _make_demographics())
+        assert 'WBC' in inputs['missing_fields']
+        wbc_issues = [i for i in inputs['unit_issues'] if i['parameter'] == 'WBC']
+        assert len(wbc_issues) == 1
+
+    def test_unknown_egfr_unit_tracked(self):
+        """eGFR with unknown unit → tracked (if creatinine fallback also fails)."""
+        raw = _make_raw_data(EGFR=[{'valueQuantity': {'value': 60, 'unit': 'weird/unit'}}])
+        inputs = PreciseHBRCalculator.extract_inputs(raw, _make_demographics())
+        assert 'eGFR' in inputs['missing_fields']
+        egfr_issues = [i for i in inputs['unit_issues'] if 'eGFR' in i['parameter']]
+        assert len(egfr_issues) == 1
+
+    def test_multiple_unknown_units_all_tracked(self):
+        """Multiple unknown units → all tracked."""
+        raw = _make_raw_data(
+            HEMOGLOBIN=[{'valueQuantity': {'value': 70, 'unit': 'mg/L'}}],
+            WBC=[{'valueQuantity': {'value': 8.5, 'unit': 'cells/uL'}}],
+        )
+        inputs = PreciseHBRCalculator.extract_inputs(raw, _make_demographics())
+        assert len(inputs['unit_issues']) == 2
+
+
+# =========================================================================
+# Calculator — Warning Generation
+# =========================================================================
+
+@pytest.mark.requirement("SRS-001")
+@pytest.mark.risk("RISK-001")
+@pytest.mark.design("SDS-001")
+class TestUnitWarningGeneration:
+    """Verify calculate_score generates unrecognized_unit warnings."""
+
+    def test_unknown_unit_generates_warning(self):
+        """Unknown Hb unit → unrecognized_unit warning in data_warnings."""
+        raw = _make_raw_data(HEMOGLOBIN=[{'valueQuantity': {'value': 70, 'unit': 'mg/L'}}])
+        components, score, warnings = PreciseHBRCalculator.calculate_score(raw, _make_demographics())
+        unit_warnings = [w for w in warnings if w['type'] == 'unrecognized_unit']
+        assert len(unit_warnings) == 1
+        assert unit_warnings[0]['parameter'] == 'Hemoglobin'
+        assert unit_warnings[0]['severity'] == 'high'
+        assert unit_warnings[0]['raw_value'] == 70
+        assert unit_warnings[0]['source_unit'] == 'mg/L'
+        assert 'unrecognized unit' in unit_warnings[0]['message'].lower()
+
+    def test_missing_unit_generates_warning(self):
+        """Missing Hb unit → unrecognized_unit warning with missing_unit status."""
+        raw = _make_raw_data(HEMOGLOBIN=[{'valueQuantity': {'value': 12.0}}])
+        components, score, warnings = PreciseHBRCalculator.calculate_score(raw, _make_demographics())
+        unit_warnings = [w for w in warnings if w['type'] == 'unrecognized_unit']
+        assert len(unit_warnings) == 1
+        assert unit_warnings[0]['status'] == UnitConversionService.STATUS_MISSING_UNIT
+        assert 'without a unit' in unit_warnings[0]['message']
+
+    def test_no_fhir_data_no_unit_warning(self):
+        """No Hb data at all → no unrecognized_unit warning."""
+        raw = _make_raw_data()
+        components, score, warnings = PreciseHBRCalculator.calculate_score(raw, _make_demographics())
+        unit_warnings = [w for w in warnings if w['type'] == 'unrecognized_unit']
+        assert len(unit_warnings) == 0
+
+    def test_known_unit_no_unit_warning(self):
+        """Known Hb unit → no unrecognized_unit warning."""
+        raw = _make_raw_data(HEMOGLOBIN=[{'valueQuantity': {'value': 12.0, 'unit': 'g/dL'}}])
+        components, score, warnings = PreciseHBRCalculator.calculate_score(raw, _make_demographics())
+        unit_warnings = [w for w in warnings if w['type'] == 'unrecognized_unit']
+        assert len(unit_warnings) == 0
+
+    def test_warning_message_includes_expected_unit(self):
+        """Warning message mentions the expected canonical unit."""
+        raw = _make_raw_data(HEMOGLOBIN=[{'valueQuantity': {'value': 70, 'unit': 'mg/L'}}])
+        _, _, warnings = PreciseHBRCalculator.calculate_score(raw, _make_demographics())
+        unit_warnings = [w for w in warnings if w['type'] == 'unrecognized_unit']
+        assert 'g/dl' in unit_warnings[0]['message'].lower() or 'g/dL' in unit_warnings[0]['message']
+
+    def test_warning_message_includes_verify(self):
+        """Warning message asks clinician to verify."""
+        raw = _make_raw_data(HEMOGLOBIN=[{'valueQuantity': {'value': 70, 'unit': 'mg/L'}}])
+        _, _, warnings = PreciseHBRCalculator.calculate_score(raw, _make_demographics())
+        unit_warnings = [w for w in warnings if w['type'] == 'unrecognized_unit']
+        assert 'verify' in unit_warnings[0]['message'].lower()
+
+    def test_hb_component_shows_not_available(self):
+        """Unknown Hb unit → component shows 'Not available', NOT the raw value."""
+        raw = _make_raw_data(HEMOGLOBIN=[{'valueQuantity': {'value': 70, 'unit': 'mg/L'}}])
+        components, score, warnings = PreciseHBRCalculator.calculate_score(raw, _make_demographics())
+        hb_comp = next(c for c in components if 'Hemoglobin' in c['parameter'])
+        assert hb_comp['value'] == 'Not available'
+        assert hb_comp['score'] == 0
+
+    def test_unknown_unit_does_not_affect_score(self):
+        """Unknown Hb unit → Hb does not contribute to score (excluded, not guessed)."""
+        raw_good = _make_raw_data(HEMOGLOBIN=[{'valueQuantity': {'value': 7.0, 'unit': 'g/dL'}}])
+        raw_bad = _make_raw_data(HEMOGLOBIN=[{'valueQuantity': {'value': 7.0, 'unit': 'mg/L'}}])
+        _, score_good, _ = PreciseHBRCalculator.calculate_score(raw_good, _make_demographics())
+        _, score_bad, _ = PreciseHBRCalculator.calculate_score(raw_bad, _make_demographics())
+        # bad unit → Hb excluded → score should be LOWER (Hb contributes 0)
+        assert score_bad < score_good
+
+
+# =========================================================================
+# Edge Cases
+# =========================================================================
+
+@pytest.mark.requirement("SRS-001")
+@pytest.mark.risk("RISK-001")
+@pytest.mark.design("SDS-001")
+class TestUnitEdgeCases:
+    """Edge cases for unit handling."""
+
+    def test_case_insensitive_unit_match(self):
+        """Unit matching is case-insensitive: 'G/DL' should work."""
+        obs = {'valueQuantity': {'value': 12.0, 'unit': 'G/DL'}}
+        result = unit_converter.get_value_with_status(obs, unit_converter.TARGET_UNITS['HEMOGLOBIN'])
+        assert result['status'] == UnitConversionService.STATUS_OK
+        assert result['value'] == 12.0
+
+    def test_unit_with_extra_whitespace(self):
+        """Extra whitespace in unit should still match."""
+        obs = {'valueQuantity': {'value': 12.0, 'unit': '  g/dL  '}}
+        result = unit_converter.get_value_with_status(obs, unit_converter.TARGET_UNITS['HEMOGLOBIN'])
+        assert result['status'] == UnitConversionService.STATUS_OK
+
+    def test_none_unit_field(self):
+        """Unit field explicitly set to None → STATUS_MISSING_UNIT."""
+        obs = {'valueQuantity': {'value': 12.0, 'unit': None}}
+        result = unit_converter.get_value_with_status(obs, unit_converter.TARGET_UNITS['HEMOGLOBIN'])
+        assert result['status'] == UnitConversionService.STATUS_MISSING_UNIT
+
+    def test_creatinine_unknown_unit_egfr_fallback_fails(self):
+        """eGFR not available + Creatinine with unknown unit → unit issue tracked."""
+        raw = _make_raw_data(
+            CREATININE=[{'valueQuantity': {'value': 1.2, 'unit': 'weird'}}]
+        )
+        inputs = PreciseHBRCalculator.extract_inputs(raw, _make_demographics())
+        assert 'eGFR' in inputs['missing_fields']
+        cr_issues = [i for i in inputs['unit_issues'] if 'Creatinine' in i['parameter']]
+        assert len(cr_issues) == 1
+
+    def test_egfr_unknown_but_creatinine_ok_no_warning(self):
+        """eGFR unknown unit but Creatinine fallback succeeds → no unit warning."""
+        raw = _make_raw_data(
+            EGFR=[{'valueQuantity': {'value': 60, 'unit': 'weird/unit'}}],
+            CREATININE=[{'valueQuantity': {'value': 1.2, 'unit': 'mg/dL'}}],
+        )
+        inputs = PreciseHBRCalculator.extract_inputs(raw, _make_demographics())
+        assert inputs['egfr'] is not None  # Creatinine fallback worked
+        egfr_issues = [i for i in inputs['unit_issues'] if 'eGFR' in i['parameter']]
+        assert len(egfr_issues) == 0


### PR DESCRIPTION
## Summary
- **Fail-Safe for Class C medical device**: 當 EHR 回傳未知單位（如 `mg/L` 代替 `g/dL`）或完全不給單位時，系統**拒絕猜測**並明確警告醫師，而非靜默當作「數據缺失」
- **新增 `get_value_with_status()`**: 回傳 5 種狀態碼（`ok`/`no_data`/`no_value`/`missing_unit`/`unknown_unit`），區分「FHIR 無資料」vs「有資料但單位無法轉換」
- **前端 alert-danger 警告**: 明確顯示原始值、未知單位、預期單位，並建議醫師手動確認
- **30 項新增測試**全數通過，Golden Dataset 21/21 通過

## Regulatory Traceability
- **Implements**: SRS-001 (PRECISE-HBR Score Calculation)
- **Design**: SDS-001 (Score Calculation Module)
- **Mitigates**: RISK-001 (Score Calculation Integrity) — 猜錯單位可能造成 10 倍量級誤差
- **Change Classification**: Class C (影響 unit_conversion_service + score calculation 輸入)

## Test plan
- [x] `tests/test_unit_failsafe.py` — 30/30 passed
- [x] `tests/verify_precise_hbr.py` — Golden Dataset 21/21 passed
- [x] `tests/test_risk_classifier.py` — 32/32 passed
- [x] `tests/test_truncation_warnings.py` — 19/19 passed
- [ ] CI Quick Tests (PR Gate) 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)