### PR TITLE
chore: 將預設 port 從 8080 改為 9000

### DIFF
--- a/APP.py
+++ b/APP.py
@@ -181,6 +181,6 @@ if __name__ == '__main__':
     else:
         host = os.environ.get("HOST", "127.0.0.1")
     
-    port = int(os.environ.get("PORT", 8080))
+    port = int(os.environ.get("PORT", 9000))
     app.logger.info(f"Server starting on {host}:{port}")
     app.run(host=host, port=port, debug=debug_mode)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### 部署 (Deployment)
+- **預設 port 從 8080 改為 9000** — 避免 VM 部署時與既有服務的端口衝突。影響 `APP.py`、`Dockerfile`、`docker-compose.yml`、`docker-compose.prod.yml`。可透過 `PORT` 環境變數覆蓋
+
 ### 安全性 (Security)
 - **修復 X-Frame-Options: DENY 阻擋 SMART on FHIR iframe 嵌入** — EHR（Epic/Cerner）透過 iframe 載入 SMART App，`DENY` 導致瀏覽器拒絕渲染：
   - 移除 `X-Frame-Options: DENY`（`after_request` + Talisman `frame_options=False`）

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ COPY . .
 
 # 6. 向 Docker 聲明容器將會監聽的 port
 # 這與我們在 gunicorn 指令中使用的 port 一致
-EXPOSE 8080
+EXPOSE 9000
 
 # 7. 設定容器啟動時要執行的指令
 # 這與您 app.yaml 中的 entrypoint 非常相似
-CMD ["gunicorn", "-b", ":8080", "--timeout", "120", "APP:app"] 
+CMD ["gunicorn", "-b", ":9000", "--timeout", "120", "APP:app"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -26,11 +26,11 @@ services:
     
     # 生產環境端口（可以使用 nginx 反向代理）
     ports:
-      - "8080:8080"
+      - "9000:9000"
     
     # 增強的健康檢查
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:9000/health"]
       interval: 15s
       timeout: 5s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,9 @@ services:
     # 為容器命名，方便管理
     container_name: smart_fhir_app
     
-    # 將主機的 8080 port 映射到容器的 8080 port
+    # 將主機的 9000 port 映射到容器的 9000 port
     ports:
-      - "8080:8080"
+      - "9000:9000"
     
     # 環境變數配置
     # 選項1：使用 .env 文件（推薦開發環境）
@@ -33,7 +33,7 @@ services:
     
     # 健康檢查
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:9000/health"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary
- 將應用程式預設 port 從 8080 改為 9000，避免 VM 上的端口衝突
- 影響檔案：`APP.py`、`Dockerfile`、`docker-compose.yml`、`docker-compose.prod.yml`

## Test plan
- [ ] 確認 `docker-compose up` 後應用在 port 9000 啟動
- [ ] 確認 healthcheck 正常運作
- [ ] 確認 `.env` 中 `SMART_REDIRECT_URI` 已更新為對應 port

🤖 Generated with [Claude Code](https://claude.com/claude-code)