### PR TITLE
feat: 首頁改為獨立 PRECISE-HBR 計算器 + Tradeoff 頁面

### DIFF
--- a/routes/web_routes.py
+++ b/routes/web_routes.py
@@ -15,11 +15,15 @@ web_bp = Blueprint('web', __name__)
 def index():
     if is_session_valid():
         return redirect(url_for('web.main_page'))
-    return redirect(url_for('web.standalone_launch_page'))
+    return render_template('standalone_calculator.html')
 
 @web_bp.route('/standalone')
 def standalone_launch_page():
     return render_template('standalone_launch.html')
+
+@web_bp.route('/standalone/tradeoff')
+def standalone_tradeoff_page():
+    return render_template('standalone_tradeoff.html')
 
 @web_bp.route('/initiate-launch', methods=['POST'])
 def initiate_launch():

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -129,7 +129,7 @@
             coefficients: {
                 age: { threshold: 30, coefficient: 0.25, truncation_min: 30, truncation_max: 80 },
                 hemoglobin: { threshold: 15.0, coefficient: 2.5, truncation_min: 5.0, truncation_max: 15.0 },
-                egfr: { threshold: 100, coefficient: 0.05, truncation_min: 5, truncation_max: 100 },
+                egfr: { threshold: 100, coefficient: 0.055, truncation_min: 5, truncation_max: 100 },
                 wbc: { threshold: 3.0, coefficient: 0.8, truncation_min: 3.0, truncation_max: 15.0 }
             },
             binary_scores: {

--- a/static/js/standalone_calculator.js
+++ b/static/js/standalone_calculator.js
@@ -1,31 +1,26 @@
 // PRECISE-HBR Standalone Calculator
-// Client-side scoring without FHIR/patient context
+// Reuses the SAME scoring config, validation ranges, unit conversion,
+// and clinical tooltips as main.js to ensure consistency.
+// All coefficients are loaded from /api/config/scoring (cdss_config.json).
 (function () {
     'use strict';
 
-    // Scoring configuration — loaded from backend, with local fallback
-    var scoringConfig = null;
+    // ======================================================================
+    // Shared state — mirrors main.js
+    // ======================================================================
+    let scoringConfig = null;
 
-    // Current hemoglobin unit
-    var hbUnit = 'g/dL';
-    var HB_CONVERSION_FACTOR = 0.6206; // 1 g/dL = 0.6206 mmol/L
-
-    // Complementary log-log calibration curve for 1-year BARC 3/5 risk
-    var CLOGLOG_A = -5.3945;
-    var CLOGLOG_B = 0.09725;
-
-    // Risk thresholds
-    var THRESHOLD_NON_HBR = 22;
-    var THRESHOLD_HBR = 26;
-
-    // Validation ranges (matching main.js)
-    var VALIDATION_RANGES = {
-        Age: { min: 18, max: 120, warnMax: 100 },
-        Hemoglobin: { min: 3, max: 22, warnMin: 7, warnMax: 18 },  // g/dL
-        eGFR: { min: 0, max: 200, warnMax: 150 },
-        WBC: { min: 0.1, max: 50, warnMin: 4, warnMax: 20 }
+    let unitSettings = {
+        hemoglobin: 'g/dL' // or 'mmol/L'
     };
 
+    // Complementary log-log calibration curve (from risk_classifier.py)
+    const CLOGLOG_A = -5.3945;
+    const CLOGLOG_B = 0.09725;
+
+    // ======================================================================
+    // Scoring config — IDENTICAL to main.js
+    // ======================================================================
     function getDefaultScoringConfig() {
         return {
             base_score: 2,
@@ -43,221 +38,379 @@
         };
     }
 
+    function validateScoringConfigResponse(data) {
+        if (!data || typeof data !== 'object') return false;
+        if (!data.coefficients || typeof data.coefficients !== 'object') return false;
+        if (!data.binary_scores || typeof data.binary_scores !== 'object') return false;
+        const requiredCoeffs = ['age', 'hemoglobin', 'egfr', 'wbc'];
+        for (const key of requiredCoeffs) {
+            const c = data.coefficients[key];
+            if (!c || typeof c.coefficient !== 'number' || typeof c.threshold !== 'number') return false;
+        }
+        return true;
+    }
+
     async function fetchScoringConfig() {
         try {
-            var response = await fetch('/api/config/scoring');
-            if (response.ok) {
-                scoringConfig = await response.json();
-            } else {
+            const response = await fetch('/api/config/scoring');
+            if (!response.ok) {
                 scoringConfig = getDefaultScoringConfig();
+                return scoringConfig;
             }
-        } catch (e) {
+            const configData = await response.json();
+            if (!validateScoringConfigResponse(configData)) {
+                scoringConfig = getDefaultScoringConfig();
+                return scoringConfig;
+            }
+            scoringConfig = configData;
+            updateTooltipsWithConfig();
+            return scoringConfig;
+        } catch (error) {
             scoringConfig = getDefaultScoringConfig();
+            return scoringConfig;
         }
-        return scoringConfig;
     }
 
-    // === Validation ===
-
-    function validateInput(inputId, paramName) {
-        var el = document.getElementById(inputId);
-        var value = parseFloat(el.value);
-        var feedbackEl = el.closest('td').querySelector('.validation-feedback');
-
-        // Clear previous feedback
-        el.classList.remove('is-invalid', 'is-warning');
-        if (feedbackEl) feedbackEl.remove();
-
-        if (el.value === '' || isNaN(value)) {
-            return { valid: true, blockCalculation: false };
+    // ======================================================================
+    // Clinical tooltips — IDENTICAL to main.js
+    // ======================================================================
+    const clinicalTooltips = {
+        'Age': {
+            title: 'Age',
+            content: 'Age is a continuous variable in the PRECISE-HBR model. It is truncated to the 30-80 years range during calculation; older age increases the score.',
+            normalRange: 'Calculation Range: 30-80 years',
+            riskFactors: 'Score Weight: +0.25 points per year increase'
+        },
+        'Hemoglobin': {
+            title: 'Hemoglobin',
+            content: 'Hemoglobin is a continuous variable in the PRECISE-HBR model. It is truncated to the 5-15 g/dL range during calculation; lower hemoglobin increases the score.',
+            normalRange: 'Calculation Range: 5-15 g/dL',
+            riskFactors: 'Score Weight: +2.5 points per 1 g/dL decrease'
+        },
+        'eGFR': {
+            title: 'eGFR (Estimated Glomerular Filtration Rate)',
+            content: 'eGFR is a continuous variable in the PRECISE-HBR model. It is truncated to the 5-100 mL/min range; lower kidney function increases the score.',
+            normalRange: 'Calculation Range: 5-100 mL/min/1.73m\u00b2',
+            riskFactors: 'Score Weight: +0.055 points per 1 mL/min decrease'
+        },
+        'White Blood Cell Count': {
+            title: 'White Blood Cell Count',
+            content: 'WBC count is a continuous variable in the PRECISE-HBR model. It is truncated to a maximum of 15 \u00d710\u00b3/\u00b5L; higher WBC increases the score.',
+            normalRange: 'Calculation Range: 3-15 \u00d710\u00b3/\u00b5L',
+            riskFactors: 'Score Weight: +0.8 points per 1 \u00d710\u00b3/\u00b5L increase'
+        },
+        'Previous bleeding': {
+            title: 'Previous Bleeding',
+            content: 'History of spontaneous bleeding is the strongest predictor of future bleeding.',
+            normalRange: 'No history of bleeding',
+            riskFactors: 'Significant risk increase (+7 points)'
+        },
+        'Long-term oral anticoagulation': {
+            title: 'Long-term Oral Anticoagulation',
+            content: 'Long-term use of oral anticoagulants (e.g., Warfarin, DOACs) significantly increases bleeding risk.',
+            normalRange: 'Not used',
+            riskFactors: 'ARC-HBR Major Criterion (+5 points)'
+        },
+        'ARC-HBR Factors': {
+            title: 'ARC-HBR Additional Factors',
+            content: 'Presence of at least one of the remaining ARC-HBR elements: thrombocytopenia, bleeding diathesis, active malignancy, liver cirrhosis with portal hypertension, recent major surgery/trauma, chronic NSAIDs/corticosteroids.',
+            normalRange: 'None present',
+            riskFactors: '+3 points if \u22651 factor present'
         }
+    };
 
-        var result = validateValue(paramName, value);
-
-        if (result.level === 'error') {
-            el.classList.add('is-invalid');
-            addFeedback(el, result.message, 'text-danger');
-        } else if (result.level === 'warning') {
-            el.classList.add('is-warning');
-            addFeedback(el, result.message, 'text-warning');
+    function updateTooltipsWithConfig() {
+        if (!scoringConfig) return;
+        const c = scoringConfig.coefficients;
+        if (clinicalTooltips['Age'] && c.age) {
+            clinicalTooltips['Age'].riskFactors =
+                `Score Weight: +${c.age.coefficient} points per year increase`;
+            clinicalTooltips['Age'].normalRange =
+                `Calculation Range: ${c.age.truncation_min}-${c.age.truncation_max} years`;
         }
-
-        return result;
+        if (clinicalTooltips['Hemoglobin'] && c.hemoglobin) {
+            clinicalTooltips['Hemoglobin'].riskFactors =
+                `Score Weight: +${c.hemoglobin.coefficient} points per 1 g/dL decrease`;
+            clinicalTooltips['Hemoglobin'].normalRange =
+                `Calculation Range: ${c.hemoglobin.truncation_min}-${c.hemoglobin.truncation_max} g/dL`;
+        }
+        if (clinicalTooltips['eGFR'] && c.egfr) {
+            clinicalTooltips['eGFR'].riskFactors =
+                `Score Weight: +${c.egfr.coefficient} points per 1 mL/min decrease`;
+        }
+        if (clinicalTooltips['White Blood Cell Count'] && c.wbc) {
+            clinicalTooltips['White Blood Cell Count'].riskFactors =
+                `Score Weight: +${c.wbc.coefficient} points per 1 \u00d710\u00b3/\u00b5L increase`;
+        }
     }
 
-    function validateValue(paramName, value) {
-        var result = { valid: true, level: 'normal', message: '', blockCalculation: false };
+    // ======================================================================
+    // Validation ranges — IDENTICAL to main.js
+    // ======================================================================
+    const VALIDATION_RANGES = {
+        Age: { min: 18, max: 120, warnMax: 100 },
+        Hemoglobin: { min: 3, max: 22, warnMin: 7, warnMax: 18 },
+        eGFR: { min: 0, max: 200, warnMax: 150 },
+        WBC: { min: 0.1, max: 50, warnMin: 4, warnMax: 20 }
+    };
 
-        if (paramName === 'Age') {
-            var r = VALIDATION_RANGES.Age;
-            if (value < r.min || value > r.max) {
+    const RISK_THRESHOLDS = {
+        NOT_HIGH: 22,
+        HBR: 23,
+        VERY_HBR: 27
+    };
+
+    // validateValue — IDENTICAL to main.js
+    function validateValue(parameterName, value) {
+        const numValue = parseFloat(value);
+        if (isNaN(numValue)) return { valid: true, level: 'normal', message: '', blockCalculation: false };
+
+        let result = { valid: true, level: 'normal', message: '', blockCalculation: false };
+
+        if (parameterName.includes("Age")) {
+            const range = VALIDATION_RANGES.Age;
+            if (numValue < range.min || numValue > range.max) {
                 result.level = 'error';
-                result.message = 'Age must be between ' + r.min + ' and ' + r.max + ' years';
+                result.message = `Age must be between ${range.min} and ${range.max} years`;
                 result.blockCalculation = true;
-            } else if (value > r.warnMax) {
+            } else if (numValue > range.warnMax) {
                 result.level = 'warning';
                 result.message = 'Age exceeds typical range (>100 years)';
-            } else if (value >= 75) {
+            } else if (numValue >= 75) {
                 result.level = 'warning';
-                result.message = 'Elderly patient (\u226575 years) \u2014 increased bleeding risk';
+                result.message = 'Elderly patient (\u226575 years) - increased bleeding risk';
             }
-        } else if (paramName === 'Hemoglobin') {
-            var r = VALIDATION_RANGES.Hemoglobin;
-            var factor = hbUnit === 'mmol/L' ? HB_CONVERSION_FACTOR : 1;
-            var min = r.min * factor, max = r.max * factor;
-            var warnMin = r.warnMin * factor, warnMax = r.warnMax * factor;
-            if (value < min || value > max) {
+        } else if (parameterName.includes("Hemoglobin")) {
+            const range = VALIDATION_RANGES.Hemoglobin;
+            const unit = unitSettings.hemoglobin || 'g/dL';
+            const factor = unit === 'mmol/L' ? 0.6206 : 1;
+            const min = range.min * factor;
+            const max = range.max * factor;
+            const warnMin = range.warnMin * factor;
+            const warnMax = range.warnMax * factor;
+
+            if (numValue < min || numValue > max) {
                 result.level = 'error';
-                result.message = 'Hemoglobin must be between ' + min.toFixed(1) + ' and ' + max.toFixed(1) + ' ' + hbUnit;
+                result.message = `Hemoglobin must be between ${min.toFixed(1)} and ${max.toFixed(1)} ${unit}`;
                 result.blockCalculation = true;
-            } else if (value < warnMin) {
+            } else if (numValue < warnMin) {
                 result.level = 'warning';
-                result.message = 'Low hemoglobin (<' + warnMin.toFixed(1) + ' ' + hbUnit + ') \u2014 Anemia';
-            } else if (value > warnMax) {
+                result.message = `Low hemoglobin (<${warnMin.toFixed(1)} ${unit}) - Anemia`;
+            } else if (numValue > warnMax) {
                 result.level = 'warning';
-                result.message = 'Elevated hemoglobin (>' + warnMax.toFixed(1) + ' ' + hbUnit + ')';
+                result.message = `Elevated hemoglobin (>${warnMax.toFixed(1)} ${unit})`;
             }
-        } else if (paramName === 'eGFR') {
-            var r = VALIDATION_RANGES.eGFR;
-            if (value < r.min || value > r.max) {
+        } else if (parameterName.includes("eGFR")) {
+            const range = VALIDATION_RANGES.eGFR;
+            if (numValue < range.min || numValue > range.max) {
                 result.level = 'error';
-                result.message = 'eGFR must be between ' + r.min + ' and ' + r.max + ' mL/min';
+                result.message = `eGFR must be between ${range.min} and ${range.max} mL/min`;
                 result.blockCalculation = true;
-            } else if (value < 15) {
+            } else if (numValue < 15) {
                 result.level = 'warning';
-                result.message = 'Severe renal impairment (<15) \u2014 Very high risk';
-            } else if (value < 30) {
+                result.message = 'Severe renal impairment (<15) - Very high risk';
+            } else if (numValue < 30) {
                 result.level = 'warning';
-                result.message = 'Severe renal impairment (<30) \u2014 High risk';
-            } else if (value < 60) {
+                result.message = 'Severe renal impairment (<30) - High risk';
+            } else if (numValue < 60) {
                 result.level = 'warning';
-                result.message = 'Moderate renal impairment (30\u201360)';
-            } else if (value > r.warnMax) {
+                result.message = 'Moderate renal impairment (30-60)';
+            } else if (numValue > range.warnMax) {
                 result.level = 'warning';
-                result.message = 'eGFR unusually high (>150) \u2014 Please verify';
+                result.message = 'eGFR unusually high (>150) - Please verify';
             }
-        } else if (paramName === 'WBC') {
-            var r = VALIDATION_RANGES.WBC;
-            if (value < r.min || value > r.max) {
+        } else if (parameterName.includes("WBC") || parameterName.includes("White Blood Cell")) {
+            const range = VALIDATION_RANGES.WBC;
+            if (numValue < range.min || numValue > range.max) {
                 result.level = 'error';
-                result.message = 'WBC must be between ' + r.min + ' and ' + r.max + ' \u00d710\u00b3/\u00b5L';
+                result.message = `WBC must be between ${range.min} and ${range.max} \u00d710\u00b3/\u00b5L`;
                 result.blockCalculation = true;
-            } else if (value < r.warnMin) {
+            } else if (numValue < range.warnMin) {
                 result.level = 'warning';
-                result.message = 'Low WBC (<4) \u2014 Leukopenia';
-            } else if (value > r.warnMax) {
+                result.message = 'Low WBC (<4 \u00d710\u00b3/\u00b5L) - Leukopenia';
+            } else if (numValue > range.warnMax) {
                 result.level = 'warning';
-                result.message = 'Elevated WBC (>20) \u2014 Leukocytosis';
+                result.message = 'Elevated WBC (>20 \u00d710\u00b3/\u00b5L) - Leukocytosis';
             }
         }
+
         return result;
     }
 
-    function addFeedback(inputEl, message, cssClass) {
-        var div = document.createElement('div');
-        div.className = 'validation-feedback small mt-1 ' + cssClass;
-        div.innerHTML = '<i class="fas fa-exclamation-circle"></i> ' + escapeHtml(message);
-        inputEl.closest('td').appendChild(div);
-    }
+    // applyValidationStyling — IDENTICAL to main.js
+    function applyValidationStyling(inputElement, validation) {
+        inputElement.classList.remove('value-normal', 'value-warning', 'value-error');
 
-    function hasValidationErrors() {
-        var validations = [
-            validateInput('input-age', 'Age'),
-            validateInput('input-hb', 'Hemoglobin'),
-            validateInput('input-egfr', 'eGFR'),
-            validateInput('input-wbc', 'WBC')
-        ];
-        return validations.some(function (v) { return v.blockCalculation; });
-    }
-
-    // === Hemoglobin unit conversion ===
-
-    function toggleHbUnit() {
-        var input = document.getElementById('input-hb');
-        var currentValue = parseFloat(input.value);
-        var newUnit = hbUnit === 'g/dL' ? 'mmol/L' : 'g/dL';
-
-        if (!isNaN(currentValue)) {
-            if (hbUnit === 'g/dL' && newUnit === 'mmol/L') {
-                input.value = (currentValue * HB_CONVERSION_FACTOR).toFixed(2);
-            } else {
-                input.value = (currentValue / HB_CONVERSION_FACTOR).toFixed(2);
-            }
+        if (validation.level === 'error') {
+            inputElement.classList.add('value-error');
+        } else if (validation.level === 'warning') {
+            inputElement.classList.add('value-warning');
+        } else {
+            inputElement.classList.add('value-normal');
         }
 
-        hbUnit = newUnit;
-        document.getElementById('hb-unit-display').textContent = newUnit;
-        document.getElementById('hb-unit-label').textContent = '(' + newUnit + ')';
+        const inputGroup = inputElement.closest('.input-group') || inputElement.parentElement;
+        const container = inputGroup.parentElement;
 
-        calculateScore();
+        const existingMessages = container.querySelectorAll('.validation-message');
+        existingMessages.forEach(msg => msg.remove());
+
+        if (validation.message) {
+            const messageDiv = document.createElement('div');
+            messageDiv.className = 'validation-message';
+            messageDiv.textContent = validation.message;
+            if (validation.level === 'error') messageDiv.classList.add('text-danger');
+            if (validation.level === 'warning') messageDiv.classList.add('text-warning');
+            container.appendChild(messageDiv);
+        }
     }
 
-    // === Score calculation ===
+    // ======================================================================
+    // Hemoglobin unit conversion — IDENTICAL to main.js
+    // ======================================================================
+    function convertHemoglobin(value, fromUnit, toUnit) {
+        if (fromUnit === toUnit) return value;
+        if (fromUnit === 'g/dL' && toUnit === 'mmol/L') return value * 0.6206;
+        if (fromUnit === 'mmol/L' && toUnit === 'g/dL') return value / 0.6206;
+        return value;
+    }
 
-    function calculateScore() {
-        var cfg = scoringConfig;
+    function toggleHemoglobinUnit() {
+        const input = document.getElementById('input-hb');
+        const currentValue = parseFloat(input.value);
+        const currentUnit = unitSettings.hemoglobin;
+        const newUnit = currentUnit === 'g/dL' ? 'mmol/L' : 'g/dL';
+
+        if (!isNaN(currentValue)) {
+            const newValue = convertHemoglobin(currentValue, currentUnit, newUnit);
+            input.value = newValue.toFixed(2);
+        }
+
+        unitSettings.hemoglobin = newUnit;
+
+        // Update unit displays
+        const unitSpan = document.getElementById('hb-unit-display');
+        if (unitSpan) unitSpan.textContent = newUnit;
+        const unitLabel = document.getElementById('hb-unit-label');
+        if (unitLabel) unitLabel.textContent = '(' + newUnit + ')';
+
+        recalculate();
+    }
+
+    // ======================================================================
+    // Tooltip rendering
+    // ======================================================================
+    function renderTooltip(key) {
+        const tip = clinicalTooltips[key];
+        if (!tip) return '';
+        return ` <span class="text-muted" tabindex="0" role="button"
+            data-bs-toggle="popover" data-bs-trigger="hover focus"
+            data-bs-html="true" data-bs-placement="right"
+            title="${escapeHtml(tip.title)}"
+            data-bs-content="<p>${escapeHtml(tip.content)}</p><p><strong>Normal:</strong> ${escapeHtml(tip.normalRange)}</p><p><strong>Risk:</strong> ${escapeHtml(tip.riskFactors)}</p>">
+            <i class="fas fa-info-circle"></i></span>`;
+    }
+
+    function initPopovers() {
+        const popoverTriggerList = document.querySelectorAll('[data-bs-toggle="popover"]');
+        popoverTriggerList.forEach(el => {
+            new bootstrap.Popover(el, { sanitize: false });
+        });
+    }
+
+    // ======================================================================
+    // Score calculation — uses scoringConfig from /api/config/scoring
+    // ======================================================================
+    function recalculate() {
+        const cfg = scoringConfig;
         if (!cfg) return;
 
-        // Run validation
-        var blocked = hasValidationErrors();
+        const c = cfg.coefficients;
+        const b = cfg.binary_scores;
 
-        var c = cfg.coefficients;
-        var b = cfg.binary_scores;
-        var total = cfg.base_score;
+        // Validate all inputs first
+        let blocked = false;
+        const inputs = [
+            { id: 'input-age', param: 'Age' },
+            { id: 'input-hb', param: 'Hemoglobin' },
+            { id: 'input-egfr', param: 'eGFR' },
+            { id: 'input-wbc', param: 'White Blood Cell Count' }
+        ];
+
+        inputs.forEach(function (item) {
+            const el = document.getElementById(item.id);
+            if (el && el.value) {
+                const v = validateValue(item.param, el.value);
+                applyValidationStyling(el, v);
+                if (v.blockCalculation) blocked = true;
+            } else if (el) {
+                // Clear validation when empty
+                applyValidationStyling(el, { level: 'normal', message: '' });
+            }
+        });
+
+        let total = cfg.base_score;
 
         // Age
-        var ageRaw = parseFloat(document.getElementById('input-age').value);
-        var ageScore = 0;
+        const ageRaw = parseFloat(document.getElementById('input-age').value);
+        let ageScore = 0;
         if (!isNaN(ageRaw)) {
-            var eff = Math.max(c.age.truncation_min, Math.min(c.age.truncation_max, ageRaw));
-            if (eff > c.age.threshold) {
-                ageScore = (eff - c.age.threshold) * c.age.coefficient;
+            const ageCfg = c.age;
+            const eff = Math.max(ageCfg.truncation_min, Math.min(ageCfg.truncation_max, ageRaw));
+            if (eff > ageCfg.threshold) {
+                ageScore = (eff - ageCfg.threshold) * ageCfg.coefficient;
             }
         }
         total += ageScore;
         document.getElementById('score-age').textContent = ageScore.toFixed(1);
 
         // Hemoglobin (convert to g/dL if in mmol/L)
-        var hbRaw = parseFloat(document.getElementById('input-hb').value);
-        var hbScore = 0;
+        const hbRaw = parseFloat(document.getElementById('input-hb').value);
+        let hbScore = 0;
         if (!isNaN(hbRaw)) {
-            var hbGdl = hbUnit === 'mmol/L' ? hbRaw / HB_CONVERSION_FACTOR : hbRaw;
-            var eff = Math.max(c.hemoglobin.truncation_min, Math.min(c.hemoglobin.truncation_max, hbGdl));
-            if (eff < c.hemoglobin.threshold) {
-                hbScore = (c.hemoglobin.threshold - eff) * c.hemoglobin.coefficient;
+            let hbGdl = hbRaw;
+            if (unitSettings.hemoglobin === 'mmol/L') {
+                hbGdl = convertHemoglobin(hbRaw, 'mmol/L', 'g/dL');
+            }
+            const hbCfg = c.hemoglobin;
+            const eff = Math.max(hbCfg.truncation_min, Math.min(hbCfg.truncation_max, hbGdl));
+            if (eff < hbCfg.threshold) {
+                hbScore = (hbCfg.threshold - eff) * hbCfg.coefficient;
             }
         }
         total += hbScore;
         document.getElementById('score-hb').textContent = hbScore.toFixed(1);
 
         // eGFR
-        var egfrRaw = parseFloat(document.getElementById('input-egfr').value);
-        var egfrScore = 0;
+        const egfrRaw = parseFloat(document.getElementById('input-egfr').value);
+        let egfrScore = 0;
         if (!isNaN(egfrRaw)) {
-            var eff = Math.max(c.egfr.truncation_min, Math.min(c.egfr.truncation_max, egfrRaw));
-            if (eff < c.egfr.threshold) {
-                egfrScore = (c.egfr.threshold - eff) * c.egfr.coefficient;
+            const egfrCfg = c.egfr;
+            const eff = Math.max(egfrCfg.truncation_min, Math.min(egfrCfg.truncation_max, egfrRaw));
+            if (eff < egfrCfg.threshold) {
+                egfrScore = (egfrCfg.threshold - eff) * egfrCfg.coefficient;
             }
         }
         total += egfrScore;
         document.getElementById('score-egfr').textContent = egfrScore.toFixed(1);
 
         // WBC
-        var wbcRaw = parseFloat(document.getElementById('input-wbc').value);
-        var wbcScore = 0;
+        const wbcRaw = parseFloat(document.getElementById('input-wbc').value);
+        let wbcScore = 0;
         if (!isNaN(wbcRaw)) {
-            var eff = Math.max(c.wbc.truncation_min, Math.min(c.wbc.truncation_max, wbcRaw));
-            if (eff > c.wbc.threshold) {
-                wbcScore = (eff - c.wbc.threshold) * c.wbc.coefficient;
+            const wbcCfg = c.wbc;
+            const eff = Math.max(wbcCfg.truncation_min, Math.min(wbcCfg.truncation_max, wbcRaw));
+            if (eff > wbcCfg.threshold) {
+                wbcScore = (eff - wbcCfg.threshold) * wbcCfg.coefficient;
             }
         }
         total += wbcScore;
         document.getElementById('score-wbc').textContent = wbcScore.toFixed(1);
 
         // Binary factors
-        var bleedingScore = document.getElementById('input-bleeding').checked ? b.prior_bleeding : 0;
-        var oacScore = document.getElementById('input-oac').checked ? b.oral_anticoagulation : 0;
-        var arcScore = document.getElementById('input-arc').checked ? b.arc_hbr : 0;
+        const bleedingScore = document.getElementById('input-bleeding').checked ? b.prior_bleeding : 0;
+        const oacScore = document.getElementById('input-oac').checked ? b.oral_anticoagulation : 0;
+        const arcScore = document.getElementById('input-arc').checked ? b.arc_hbr : 0;
 
         total += bleedingScore + oacScore + arcScore;
 
@@ -265,52 +418,63 @@
         document.getElementById('score-oac').textContent = oacScore;
         document.getElementById('score-arc').textContent = arcScore;
 
-        // Round total
-        var roundedTotal = Math.floor(total + 0.5);
+        // Round (same as main.js: Math.round)
+        const finalScore = Math.round(total);
 
         if (blocked) {
             document.getElementById('total-score').textContent = '--';
             document.getElementById('total-score').className = 'display-3 fw-bold text-muted';
-            document.getElementById('risk-level').innerHTML = '<span class="badge bg-secondary">Invalid input</span>';
+            document.getElementById('risk-level').innerHTML =
+                '<span class="badge bg-secondary">Invalid input</span>';
             document.getElementById('risk-percent').textContent = '';
-            document.getElementById('recommendation').textContent = 'Please correct the highlighted values above.';
+            document.getElementById('recommendation').textContent =
+                'Please correct the highlighted values above.';
             document.getElementById('hbr-recommendations-section').classList.add('d-none');
             return;
         }
 
-        updateScoreDisplay(roundedTotal);
+        updateScoreDisplay(finalScore);
     }
 
+    // ======================================================================
+    // Risk % — cloglog from risk_classifier.py
+    // ======================================================================
     function calculateRiskPercent(score) {
-        var lp = CLOGLOG_A + CLOGLOG_B * score;
-        var risk = 1.0 - Math.exp(-Math.exp(lp));
+        const lp = CLOGLOG_A + CLOGLOG_B * score;
+        const risk = 1.0 - Math.exp(-Math.exp(lp));
         return (risk * 100).toFixed(2);
     }
 
+    // ======================================================================
+    // UI update — mirrors updateTotalScoreUI from main.js
+    // ======================================================================
     function updateScoreDisplay(score) {
-        var totalEl = document.getElementById('total-score');
-        var riskEl = document.getElementById('risk-level');
-        var riskPctEl = document.getElementById('risk-percent');
-        var recommendEl = document.getElementById('recommendation');
-        var hbrSection = document.getElementById('hbr-recommendations-section');
+        const totalEl = document.getElementById('total-score');
+        const riskEl = document.getElementById('risk-level');
+        const riskPctEl = document.getElementById('risk-percent');
+        const recommendEl = document.getElementById('recommendation');
+        const hbrSection = document.getElementById('hbr-recommendations-section');
 
         totalEl.textContent = score;
 
-        var riskPct = calculateRiskPercent(score);
+        const riskPct = calculateRiskPercent(score);
 
-        var category, colorClass, scoreRange;
-        if (score <= THRESHOLD_NON_HBR) {
+        let category, colorClass, scoreRange, scoreColor;
+        if (score <= RISK_THRESHOLDS.NOT_HIGH) {
             category = 'Not high bleeding risk';
             colorClass = 'bg-success';
-            scoreRange = '(score \u226422)';
-        } else if (score <= THRESHOLD_HBR) {
+            scoreRange = `(score \u2264${RISK_THRESHOLDS.NOT_HIGH})`;
+            scoreColor = 'text-success';
+        } else if (score < RISK_THRESHOLDS.VERY_HBR) {
             category = 'High bleeding risk (HBR)';
             colorClass = 'bg-warning text-dark';
-            scoreRange = '(score 23\u201326)';
+            scoreRange = `(score ${RISK_THRESHOLDS.HBR}\u2013${RISK_THRESHOLDS.VERY_HBR - 1})`;
+            scoreColor = 'text-warning';
         } else {
             category = 'Very high bleeding risk';
             colorClass = 'bg-danger';
-            scoreRange = '(score \u226527)';
+            scoreRange = `(score \u2265${RISK_THRESHOLDS.VERY_HBR})`;
+            scoreColor = 'text-danger';
         }
 
         riskEl.innerHTML = '<span class="badge ' + colorClass + '">' +
@@ -319,52 +483,69 @@
 
         riskPctEl.textContent = '1-year risk of major bleeding (BARC 3/5): ' + riskPct + '%';
 
-        recommendEl.textContent = score <= THRESHOLD_NON_HBR
+        recommendEl.textContent = score <= RISK_THRESHOLDS.NOT_HIGH
             ? 'Standard DAPT duration per guidelines.'
             : 'Consider abbreviated DAPT or de-escalation strategy.';
 
         // Show/hide HBR recommendations
-        if (score >= THRESHOLD_NON_HBR + 1) {
+        if (score >= RISK_THRESHOLDS.HBR) {
             hbrSection.classList.remove('d-none');
         } else {
             hbrSection.classList.add('d-none');
         }
 
-        // Color the score number
-        totalEl.className = 'display-3 fw-bold';
-        if (score <= THRESHOLD_NON_HBR) {
-            totalEl.classList.add('text-success');
-        } else if (score <= THRESHOLD_HBR) {
-            totalEl.classList.add('text-warning');
-        } else {
-            totalEl.classList.add('text-danger');
-        }
+        totalEl.className = 'display-3 fw-bold ' + scoreColor;
     }
 
     function escapeHtml(str) {
-        var div = document.createElement('div');
+        const div = document.createElement('div');
         div.appendChild(document.createTextNode(str));
         return div.innerHTML;
     }
 
+    // ======================================================================
     // Initialisation
+    // ======================================================================
     async function init() {
         await fetchScoringConfig();
 
+        // Add tooltips to parameter labels
+        const tooltipTargets = {
+            'input-age': 'Age',
+            'input-hb': 'Hemoglobin',
+            'input-egfr': 'eGFR',
+            'input-wbc': 'White Blood Cell Count',
+            'input-bleeding': 'Previous bleeding',
+            'input-oac': 'Long-term oral anticoagulation',
+            'input-arc': 'ARC-HBR Factors'
+        };
+
+        Object.entries(tooltipTargets).forEach(([inputId, tooltipKey]) => {
+            const input = document.getElementById(inputId);
+            if (input) {
+                const td = input.closest('tr').querySelector('td:first-child');
+                if (td) {
+                    td.insertAdjacentHTML('beforeend', renderTooltip(tooltipKey));
+                }
+            }
+        });
+
+        initPopovers();
+
         // Bind input listeners
         document.querySelectorAll('#score-components input').forEach(function (input) {
-            input.addEventListener('input', calculateScore);
-            input.addEventListener('change', calculateScore);
+            input.addEventListener('input', recalculate);
+            input.addEventListener('change', recalculate);
         });
 
         // Bind Hb unit toggle
-        var toggleBtn = document.getElementById('hb-unit-toggle');
+        const toggleBtn = document.getElementById('hb-unit-toggle');
         if (toggleBtn) {
-            toggleBtn.addEventListener('click', toggleHbUnit);
+            toggleBtn.addEventListener('click', toggleHemoglobinUnit);
         }
 
         // Initial calculation
-        calculateScore();
+        recalculate();
     }
 
     if (document.readyState === 'loading') {

--- a/static/js/standalone_calculator.js
+++ b/static/js/standalone_calculator.js
@@ -4,15 +4,27 @@
     'use strict';
 
     // Scoring configuration — loaded from backend, with local fallback
-    let scoringConfig = null;
+    var scoringConfig = null;
+
+    // Current hemoglobin unit
+    var hbUnit = 'g/dL';
+    var HB_CONVERSION_FACTOR = 0.6206; // 1 g/dL = 0.6206 mmol/L
 
     // Complementary log-log calibration curve for 1-year BARC 3/5 risk
-    const CLOGLOG_A = -5.3945;
-    const CLOGLOG_B = 0.09725;
+    var CLOGLOG_A = -5.3945;
+    var CLOGLOG_B = 0.09725;
 
     // Risk thresholds
-    const THRESHOLD_NON_HBR = 22;
-    const THRESHOLD_HBR = 26;
+    var THRESHOLD_NON_HBR = 22;
+    var THRESHOLD_HBR = 26;
+
+    // Validation ranges (matching main.js)
+    var VALIDATION_RANGES = {
+        Age: { min: 18, max: 120, warnMax: 100 },
+        Hemoglobin: { min: 3, max: 22, warnMin: 7, warnMax: 18 },  // g/dL
+        eGFR: { min: 0, max: 200, warnMax: 150 },
+        WBC: { min: 0.1, max: 50, warnMin: 4, warnMax: 20 }
+    };
 
     function getDefaultScoringConfig() {
         return {
@@ -33,7 +45,7 @@
 
     async function fetchScoringConfig() {
         try {
-            const response = await fetch('/api/config/scoring');
+            var response = await fetch('/api/config/scoring');
             if (response.ok) {
                 scoringConfig = await response.json();
             } else {
@@ -45,19 +57,159 @@
         return scoringConfig;
     }
 
+    // === Validation ===
+
+    function validateInput(inputId, paramName) {
+        var el = document.getElementById(inputId);
+        var value = parseFloat(el.value);
+        var feedbackEl = el.closest('td').querySelector('.validation-feedback');
+
+        // Clear previous feedback
+        el.classList.remove('is-invalid', 'is-warning');
+        if (feedbackEl) feedbackEl.remove();
+
+        if (el.value === '' || isNaN(value)) {
+            return { valid: true, blockCalculation: false };
+        }
+
+        var result = validateValue(paramName, value);
+
+        if (result.level === 'error') {
+            el.classList.add('is-invalid');
+            addFeedback(el, result.message, 'text-danger');
+        } else if (result.level === 'warning') {
+            el.classList.add('is-warning');
+            addFeedback(el, result.message, 'text-warning');
+        }
+
+        return result;
+    }
+
+    function validateValue(paramName, value) {
+        var result = { valid: true, level: 'normal', message: '', blockCalculation: false };
+
+        if (paramName === 'Age') {
+            var r = VALIDATION_RANGES.Age;
+            if (value < r.min || value > r.max) {
+                result.level = 'error';
+                result.message = 'Age must be between ' + r.min + ' and ' + r.max + ' years';
+                result.blockCalculation = true;
+            } else if (value > r.warnMax) {
+                result.level = 'warning';
+                result.message = 'Age exceeds typical range (>100 years)';
+            } else if (value >= 75) {
+                result.level = 'warning';
+                result.message = 'Elderly patient (\u226575 years) \u2014 increased bleeding risk';
+            }
+        } else if (paramName === 'Hemoglobin') {
+            var r = VALIDATION_RANGES.Hemoglobin;
+            var factor = hbUnit === 'mmol/L' ? HB_CONVERSION_FACTOR : 1;
+            var min = r.min * factor, max = r.max * factor;
+            var warnMin = r.warnMin * factor, warnMax = r.warnMax * factor;
+            if (value < min || value > max) {
+                result.level = 'error';
+                result.message = 'Hemoglobin must be between ' + min.toFixed(1) + ' and ' + max.toFixed(1) + ' ' + hbUnit;
+                result.blockCalculation = true;
+            } else if (value < warnMin) {
+                result.level = 'warning';
+                result.message = 'Low hemoglobin (<' + warnMin.toFixed(1) + ' ' + hbUnit + ') \u2014 Anemia';
+            } else if (value > warnMax) {
+                result.level = 'warning';
+                result.message = 'Elevated hemoglobin (>' + warnMax.toFixed(1) + ' ' + hbUnit + ')';
+            }
+        } else if (paramName === 'eGFR') {
+            var r = VALIDATION_RANGES.eGFR;
+            if (value < r.min || value > r.max) {
+                result.level = 'error';
+                result.message = 'eGFR must be between ' + r.min + ' and ' + r.max + ' mL/min';
+                result.blockCalculation = true;
+            } else if (value < 15) {
+                result.level = 'warning';
+                result.message = 'Severe renal impairment (<15) \u2014 Very high risk';
+            } else if (value < 30) {
+                result.level = 'warning';
+                result.message = 'Severe renal impairment (<30) \u2014 High risk';
+            } else if (value < 60) {
+                result.level = 'warning';
+                result.message = 'Moderate renal impairment (30\u201360)';
+            } else if (value > r.warnMax) {
+                result.level = 'warning';
+                result.message = 'eGFR unusually high (>150) \u2014 Please verify';
+            }
+        } else if (paramName === 'WBC') {
+            var r = VALIDATION_RANGES.WBC;
+            if (value < r.min || value > r.max) {
+                result.level = 'error';
+                result.message = 'WBC must be between ' + r.min + ' and ' + r.max + ' \u00d710\u00b3/\u00b5L';
+                result.blockCalculation = true;
+            } else if (value < r.warnMin) {
+                result.level = 'warning';
+                result.message = 'Low WBC (<4) \u2014 Leukopenia';
+            } else if (value > r.warnMax) {
+                result.level = 'warning';
+                result.message = 'Elevated WBC (>20) \u2014 Leukocytosis';
+            }
+        }
+        return result;
+    }
+
+    function addFeedback(inputEl, message, cssClass) {
+        var div = document.createElement('div');
+        div.className = 'validation-feedback small mt-1 ' + cssClass;
+        div.innerHTML = '<i class="fas fa-exclamation-circle"></i> ' + escapeHtml(message);
+        inputEl.closest('td').appendChild(div);
+    }
+
+    function hasValidationErrors() {
+        var validations = [
+            validateInput('input-age', 'Age'),
+            validateInput('input-hb', 'Hemoglobin'),
+            validateInput('input-egfr', 'eGFR'),
+            validateInput('input-wbc', 'WBC')
+        ];
+        return validations.some(function (v) { return v.blockCalculation; });
+    }
+
+    // === Hemoglobin unit conversion ===
+
+    function toggleHbUnit() {
+        var input = document.getElementById('input-hb');
+        var currentValue = parseFloat(input.value);
+        var newUnit = hbUnit === 'g/dL' ? 'mmol/L' : 'g/dL';
+
+        if (!isNaN(currentValue)) {
+            if (hbUnit === 'g/dL' && newUnit === 'mmol/L') {
+                input.value = (currentValue * HB_CONVERSION_FACTOR).toFixed(2);
+            } else {
+                input.value = (currentValue / HB_CONVERSION_FACTOR).toFixed(2);
+            }
+        }
+
+        hbUnit = newUnit;
+        document.getElementById('hb-unit-display').textContent = newUnit;
+        document.getElementById('hb-unit-label').textContent = '(' + newUnit + ')';
+
+        calculateScore();
+    }
+
+    // === Score calculation ===
+
     function calculateScore() {
-        const cfg = scoringConfig;
+        var cfg = scoringConfig;
         if (!cfg) return;
 
-        const c = cfg.coefficients;
-        const b = cfg.binary_scores;
-        let total = cfg.base_score;
+        // Run validation
+        var blocked = hasValidationErrors();
+
+        var c = cfg.coefficients;
+        var b = cfg.binary_scores;
+        var total = cfg.base_score;
 
         // Age
-        const ageRaw = parseFloat(document.getElementById('input-age').value);
-        let ageScore = 0;
+        var ageRaw = parseFloat(document.getElementById('input-age').value);
+        var ageScore = 0;
         if (!isNaN(ageRaw)) {
-            const eff = Math.max(c.age.truncation_min, Math.min(c.age.truncation_max, ageRaw));
+            var eff = Math.max(c.age.truncation_min, Math.min(c.age.truncation_max, ageRaw));
             if (eff > c.age.threshold) {
                 ageScore = (eff - c.age.threshold) * c.age.coefficient;
             }
@@ -65,11 +217,12 @@
         total += ageScore;
         document.getElementById('score-age').textContent = ageScore.toFixed(1);
 
-        // Hemoglobin
-        const hbRaw = parseFloat(document.getElementById('input-hb').value);
-        let hbScore = 0;
+        // Hemoglobin (convert to g/dL if in mmol/L)
+        var hbRaw = parseFloat(document.getElementById('input-hb').value);
+        var hbScore = 0;
         if (!isNaN(hbRaw)) {
-            const eff = Math.max(c.hemoglobin.truncation_min, Math.min(c.hemoglobin.truncation_max, hbRaw));
+            var hbGdl = hbUnit === 'mmol/L' ? hbRaw / HB_CONVERSION_FACTOR : hbRaw;
+            var eff = Math.max(c.hemoglobin.truncation_min, Math.min(c.hemoglobin.truncation_max, hbGdl));
             if (eff < c.hemoglobin.threshold) {
                 hbScore = (c.hemoglobin.threshold - eff) * c.hemoglobin.coefficient;
             }
@@ -78,10 +231,10 @@
         document.getElementById('score-hb').textContent = hbScore.toFixed(1);
 
         // eGFR
-        const egfrRaw = parseFloat(document.getElementById('input-egfr').value);
-        let egfrScore = 0;
+        var egfrRaw = parseFloat(document.getElementById('input-egfr').value);
+        var egfrScore = 0;
         if (!isNaN(egfrRaw)) {
-            const eff = Math.max(c.egfr.truncation_min, Math.min(c.egfr.truncation_max, egfrRaw));
+            var eff = Math.max(c.egfr.truncation_min, Math.min(c.egfr.truncation_max, egfrRaw));
             if (eff < c.egfr.threshold) {
                 egfrScore = (c.egfr.threshold - eff) * c.egfr.coefficient;
             }
@@ -90,10 +243,10 @@
         document.getElementById('score-egfr').textContent = egfrScore.toFixed(1);
 
         // WBC
-        const wbcRaw = parseFloat(document.getElementById('input-wbc').value);
-        let wbcScore = 0;
+        var wbcRaw = parseFloat(document.getElementById('input-wbc').value);
+        var wbcScore = 0;
         if (!isNaN(wbcRaw)) {
-            const eff = Math.max(c.wbc.truncation_min, Math.min(c.wbc.truncation_max, wbcRaw));
+            var eff = Math.max(c.wbc.truncation_min, Math.min(c.wbc.truncation_max, wbcRaw));
             if (eff > c.wbc.threshold) {
                 wbcScore = (eff - c.wbc.threshold) * c.wbc.coefficient;
             }
@@ -102,13 +255,9 @@
         document.getElementById('score-wbc').textContent = wbcScore.toFixed(1);
 
         // Binary factors
-        const bleeding = document.getElementById('input-bleeding').checked;
-        const oac = document.getElementById('input-oac').checked;
-        const arc = document.getElementById('input-arc').checked;
-
-        const bleedingScore = bleeding ? b.prior_bleeding : 0;
-        const oacScore = oac ? b.oral_anticoagulation : 0;
-        const arcScore = arc ? b.arc_hbr : 0;
+        var bleedingScore = document.getElementById('input-bleeding').checked ? b.prior_bleeding : 0;
+        var oacScore = document.getElementById('input-oac').checked ? b.oral_anticoagulation : 0;
+        var arcScore = document.getElementById('input-arc').checked ? b.arc_hbr : 0;
 
         total += bleedingScore + oacScore + arcScore;
 
@@ -117,30 +266,39 @@
         document.getElementById('score-arc').textContent = arcScore;
 
         // Round total
-        const roundedTotal = Math.floor(total + 0.5);
+        var roundedTotal = Math.floor(total + 0.5);
 
-        // Update display
+        if (blocked) {
+            document.getElementById('total-score').textContent = '--';
+            document.getElementById('total-score').className = 'display-3 fw-bold text-muted';
+            document.getElementById('risk-level').innerHTML = '<span class="badge bg-secondary">Invalid input</span>';
+            document.getElementById('risk-percent').textContent = '';
+            document.getElementById('recommendation').textContent = 'Please correct the highlighted values above.';
+            document.getElementById('hbr-recommendations-section').classList.add('d-none');
+            return;
+        }
+
         updateScoreDisplay(roundedTotal);
     }
 
     function calculateRiskPercent(score) {
-        const lp = CLOGLOG_A + CLOGLOG_B * score;
-        const risk = 1.0 - Math.exp(-Math.exp(lp));
+        var lp = CLOGLOG_A + CLOGLOG_B * score;
+        var risk = 1.0 - Math.exp(-Math.exp(lp));
         return (risk * 100).toFixed(2);
     }
 
     function updateScoreDisplay(score) {
-        const totalEl = document.getElementById('total-score');
-        const riskEl = document.getElementById('risk-level');
-        const riskPctEl = document.getElementById('risk-percent');
-        const recommendEl = document.getElementById('recommendation');
-        const hbrSection = document.getElementById('hbr-recommendations-section');
+        var totalEl = document.getElementById('total-score');
+        var riskEl = document.getElementById('risk-level');
+        var riskPctEl = document.getElementById('risk-percent');
+        var recommendEl = document.getElementById('recommendation');
+        var hbrSection = document.getElementById('hbr-recommendations-section');
 
         totalEl.textContent = score;
 
-        const riskPct = calculateRiskPercent(score);
+        var riskPct = calculateRiskPercent(score);
 
-        let category, colorClass, scoreRange;
+        var category, colorClass, scoreRange;
         if (score <= THRESHOLD_NON_HBR) {
             category = 'Not high bleeding risk';
             colorClass = 'bg-success';
@@ -193,12 +351,17 @@
     async function init() {
         await fetchScoringConfig();
 
-        // Bind event listeners
-        var inputs = document.querySelectorAll('#score-components input');
-        inputs.forEach(function (input) {
+        // Bind input listeners
+        document.querySelectorAll('#score-components input').forEach(function (input) {
             input.addEventListener('input', calculateScore);
             input.addEventListener('change', calculateScore);
         });
+
+        // Bind Hb unit toggle
+        var toggleBtn = document.getElementById('hb-unit-toggle');
+        if (toggleBtn) {
+            toggleBtn.addEventListener('click', toggleHbUnit);
+        }
 
         // Initial calculation
         calculateScore();

--- a/static/js/standalone_calculator.js
+++ b/static/js/standalone_calculator.js
@@ -1,0 +1,212 @@
+// PRECISE-HBR Standalone Calculator
+// Client-side scoring without FHIR/patient context
+(function () {
+    'use strict';
+
+    // Scoring configuration — loaded from backend, with local fallback
+    let scoringConfig = null;
+
+    // Complementary log-log calibration curve for 1-year BARC 3/5 risk
+    const CLOGLOG_A = -5.3945;
+    const CLOGLOG_B = 0.09725;
+
+    // Risk thresholds
+    const THRESHOLD_NON_HBR = 22;
+    const THRESHOLD_HBR = 26;
+
+    function getDefaultScoringConfig() {
+        return {
+            base_score: 2,
+            coefficients: {
+                age: { threshold: 30, coefficient: 0.25, truncation_min: 30, truncation_max: 80 },
+                hemoglobin: { threshold: 15.0, coefficient: 2.5, truncation_min: 5.0, truncation_max: 15.0 },
+                egfr: { threshold: 100, coefficient: 0.055, truncation_min: 5, truncation_max: 100 },
+                wbc: { threshold: 3.0, coefficient: 0.8, truncation_min: 3.0, truncation_max: 15.0 }
+            },
+            binary_scores: {
+                prior_bleeding: 7,
+                oral_anticoagulation: 5,
+                arc_hbr: 3
+            }
+        };
+    }
+
+    async function fetchScoringConfig() {
+        try {
+            const response = await fetch('/api/config/scoring');
+            if (response.ok) {
+                scoringConfig = await response.json();
+            } else {
+                scoringConfig = getDefaultScoringConfig();
+            }
+        } catch (e) {
+            scoringConfig = getDefaultScoringConfig();
+        }
+        return scoringConfig;
+    }
+
+    function calculateScore() {
+        const cfg = scoringConfig;
+        if (!cfg) return;
+
+        const c = cfg.coefficients;
+        const b = cfg.binary_scores;
+        let total = cfg.base_score;
+
+        // Age
+        const ageRaw = parseFloat(document.getElementById('input-age').value);
+        let ageScore = 0;
+        if (!isNaN(ageRaw)) {
+            const eff = Math.max(c.age.truncation_min, Math.min(c.age.truncation_max, ageRaw));
+            if (eff > c.age.threshold) {
+                ageScore = (eff - c.age.threshold) * c.age.coefficient;
+            }
+        }
+        total += ageScore;
+        document.getElementById('score-age').textContent = ageScore.toFixed(1);
+
+        // Hemoglobin
+        const hbRaw = parseFloat(document.getElementById('input-hb').value);
+        let hbScore = 0;
+        if (!isNaN(hbRaw)) {
+            const eff = Math.max(c.hemoglobin.truncation_min, Math.min(c.hemoglobin.truncation_max, hbRaw));
+            if (eff < c.hemoglobin.threshold) {
+                hbScore = (c.hemoglobin.threshold - eff) * c.hemoglobin.coefficient;
+            }
+        }
+        total += hbScore;
+        document.getElementById('score-hb').textContent = hbScore.toFixed(1);
+
+        // eGFR
+        const egfrRaw = parseFloat(document.getElementById('input-egfr').value);
+        let egfrScore = 0;
+        if (!isNaN(egfrRaw)) {
+            const eff = Math.max(c.egfr.truncation_min, Math.min(c.egfr.truncation_max, egfrRaw));
+            if (eff < c.egfr.threshold) {
+                egfrScore = (c.egfr.threshold - eff) * c.egfr.coefficient;
+            }
+        }
+        total += egfrScore;
+        document.getElementById('score-egfr').textContent = egfrScore.toFixed(1);
+
+        // WBC
+        const wbcRaw = parseFloat(document.getElementById('input-wbc').value);
+        let wbcScore = 0;
+        if (!isNaN(wbcRaw)) {
+            const eff = Math.max(c.wbc.truncation_min, Math.min(c.wbc.truncation_max, wbcRaw));
+            if (eff > c.wbc.threshold) {
+                wbcScore = (eff - c.wbc.threshold) * c.wbc.coefficient;
+            }
+        }
+        total += wbcScore;
+        document.getElementById('score-wbc').textContent = wbcScore.toFixed(1);
+
+        // Binary factors
+        const bleeding = document.getElementById('input-bleeding').checked;
+        const oac = document.getElementById('input-oac').checked;
+        const arc = document.getElementById('input-arc').checked;
+
+        const bleedingScore = bleeding ? b.prior_bleeding : 0;
+        const oacScore = oac ? b.oral_anticoagulation : 0;
+        const arcScore = arc ? b.arc_hbr : 0;
+
+        total += bleedingScore + oacScore + arcScore;
+
+        document.getElementById('score-bleeding').textContent = bleedingScore;
+        document.getElementById('score-oac').textContent = oacScore;
+        document.getElementById('score-arc').textContent = arcScore;
+
+        // Round total
+        const roundedTotal = Math.floor(total + 0.5);
+
+        // Update display
+        updateScoreDisplay(roundedTotal);
+    }
+
+    function calculateRiskPercent(score) {
+        const lp = CLOGLOG_A + CLOGLOG_B * score;
+        const risk = 1.0 - Math.exp(-Math.exp(lp));
+        return (risk * 100).toFixed(2);
+    }
+
+    function updateScoreDisplay(score) {
+        const totalEl = document.getElementById('total-score');
+        const riskEl = document.getElementById('risk-level');
+        const riskPctEl = document.getElementById('risk-percent');
+        const recommendEl = document.getElementById('recommendation');
+        const hbrSection = document.getElementById('hbr-recommendations-section');
+
+        totalEl.textContent = score;
+
+        const riskPct = calculateRiskPercent(score);
+
+        let category, colorClass, scoreRange;
+        if (score <= THRESHOLD_NON_HBR) {
+            category = 'Not high bleeding risk';
+            colorClass = 'bg-success';
+            scoreRange = '(score \u226422)';
+        } else if (score <= THRESHOLD_HBR) {
+            category = 'High bleeding risk (HBR)';
+            colorClass = 'bg-warning text-dark';
+            scoreRange = '(score 23\u201326)';
+        } else {
+            category = 'Very high bleeding risk';
+            colorClass = 'bg-danger';
+            scoreRange = '(score \u226527)';
+        }
+
+        riskEl.innerHTML = '<span class="badge ' + colorClass + '">' +
+            escapeHtml(category) + '</span> <small class="text-muted">' +
+            escapeHtml(scoreRange) + '</small>';
+
+        riskPctEl.textContent = '1-year risk of major bleeding (BARC 3/5): ' + riskPct + '%';
+
+        recommendEl.textContent = score <= THRESHOLD_NON_HBR
+            ? 'Standard DAPT duration per guidelines.'
+            : 'Consider abbreviated DAPT or de-escalation strategy.';
+
+        // Show/hide HBR recommendations
+        if (score >= THRESHOLD_NON_HBR + 1) {
+            hbrSection.classList.remove('d-none');
+        } else {
+            hbrSection.classList.add('d-none');
+        }
+
+        // Color the score number
+        totalEl.className = 'display-3 fw-bold';
+        if (score <= THRESHOLD_NON_HBR) {
+            totalEl.classList.add('text-success');
+        } else if (score <= THRESHOLD_HBR) {
+            totalEl.classList.add('text-warning');
+        } else {
+            totalEl.classList.add('text-danger');
+        }
+    }
+
+    function escapeHtml(str) {
+        var div = document.createElement('div');
+        div.appendChild(document.createTextNode(str));
+        return div.innerHTML;
+    }
+
+    // Initialisation
+    async function init() {
+        await fetchScoringConfig();
+
+        // Bind event listeners
+        var inputs = document.querySelectorAll('#score-components input');
+        inputs.forEach(function (input) {
+            input.addEventListener('input', calculateScore);
+            input.addEventListener('change', calculateScore);
+        });
+
+        // Initial calculation
+        calculateScore();
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/static/js/standalone_calculator.js
+++ b/static/js/standalone_calculator.js
@@ -314,7 +314,7 @@
     function initPopovers() {
         const popoverTriggerList = document.querySelectorAll('[data-bs-toggle="popover"]');
         popoverTriggerList.forEach(el => {
-            new bootstrap.Popover(el, { sanitize: false });
+            new bootstrap.Popover(el);
         });
     }
 
@@ -532,10 +532,19 @@
 
         initPopovers();
 
-        // Bind input listeners
+        // Update base score display from config
+        const baseScoreEl = document.getElementById('score-base');
+        if (baseScoreEl && scoringConfig) {
+            baseScoreEl.textContent = scoringConfig.base_score;
+        }
+
+        // Bind input listeners — 'input' for number fields, 'change' for checkboxes
         document.querySelectorAll('#score-components input').forEach(function (input) {
-            input.addEventListener('input', recalculate);
-            input.addEventListener('change', recalculate);
+            if (input.type === 'checkbox') {
+                input.addEventListener('change', recalculate);
+            } else {
+                input.addEventListener('input', recalculate);
+            }
         });
 
         // Bind Hb unit toggle

--- a/static/js/standalone_tradeoff.js
+++ b/static/js/standalone_tradeoff.js
@@ -1,0 +1,168 @@
+// ARC-HBR Standalone Tradeoff Calculator
+// Client-side Cox-PH calculation without FHIR/patient context
+(function () {
+    'use strict';
+
+    // Baseline 1-year event rate (validated against official ARC-HBR app)
+    var BASELINE_RATE = 0.014; // 1.4%
+    var BASELINE_HAZARD = -Math.log(1 - BASELINE_RATE);
+
+    // Mortality weighting ratio (bleeding mortality ~1.9x ischemia mortality)
+    var MORTALITY_RATIO = 1.9;
+
+    // ARC-HBR model predictors (from Urban et al. JAMA Cardiol 2021, Table 3)
+    var BLEEDING_PREDICTORS = [
+        { factor: 'age_ge_65',           hr: 1.50, label: 'Age \u226565 (HR 1.50)' },
+        { factor: 'liver_cancer_surgery', hr: 1.63, label: 'Liver disease/cancer/surgery (HR 1.63)' },
+        { factor: 'copd',                hr: 1.39, label: 'COPD (HR 1.39)' },
+        { factor: 'smoker',              hr: 1.47, label: 'Current smoker (HR 1.47)' },
+        { factor: 'hemoglobin_11_12.9',  hr: 1.69, label: 'Hb 11\u201312.9 g/dL (HR 1.69)' },
+        { factor: 'hemoglobin_lt_11',    hr: 3.99, label: 'Hb <11 g/dL (HR 3.99)' },
+        { factor: 'egfr_lt_30',          hr: 1.43, label: 'eGFR <30 (HR 1.43)' },
+        { factor: 'complex_pci',         hr: 1.32, label: 'Complex PCI (HR 1.32)' },
+        { factor: 'oac_discharge',       hr: 2.00, label: 'OAC at discharge (HR 2.00)' }
+    ];
+
+    var THROMBOTIC_PREDICTORS = [
+        { factor: 'diabetes',            hr: 1.56, label: 'Diabetes (HR 1.56)' },
+        { factor: 'prior_mi',            hr: 1.89, label: 'Prior MI (HR 1.89)' },
+        { factor: 'smoker',              hr: 1.48, label: 'Current smoker (HR 1.48)' },
+        { factor: 'nstemi_stemi',        hr: 1.82, label: 'NSTEMI/STEMI (HR 1.82)' },
+        { factor: 'hemoglobin_11_12.9',  hr: 1.27, label: 'Hb 11\u201312.9 g/dL (HR 1.27)' },
+        { factor: 'hemoglobin_lt_11',    hr: 1.50, label: 'Hb <11 g/dL (HR 1.50)' },
+        { factor: 'egfr_30_59',          hr: 1.30, label: 'eGFR 30\u201359 (HR 1.30)' },
+        { factor: 'egfr_lt_30',          hr: 1.69, label: 'eGFR <30 (HR 1.69)' },
+        { factor: 'complex_pci',         hr: 1.50, label: 'Complex PCI (HR 1.50)' },
+        { factor: 'bms',                 hr: 1.53, label: 'Bare metal stent (HR 1.53)' }
+    ];
+
+    function getActiveFactors() {
+        var factors = {};
+
+        // Checkboxes
+        var checkboxIds = [
+            'age_ge_65', 'diabetes', 'prior_mi', 'smoker', 'nstemi_stemi',
+            'copd', 'liver_cancer_surgery', 'complex_pci', 'bms', 'oac_discharge'
+        ];
+        checkboxIds.forEach(function (id) {
+            var el = document.getElementById('tf-' + id);
+            if (el && el.checked) {
+                factors[id] = true;
+            }
+        });
+
+        // Hb select
+        var hbSelect = document.getElementById('tf-hb-select');
+        if (hbSelect && hbSelect.value !== 'normal') {
+            factors[hbSelect.value] = true;
+        }
+
+        // eGFR select
+        var egfrSelect = document.getElementById('tf-egfr-select');
+        if (egfrSelect && egfrSelect.value !== 'normal') {
+            factors[egfrSelect.value] = true;
+        }
+
+        return factors;
+    }
+
+    function calculateRisk(predictors, activeFactors) {
+        var hrProduct = 1.0;
+        var activeList = [];
+
+        predictors.forEach(function (p) {
+            if (activeFactors[p.factor]) {
+                hrProduct *= p.hr;
+                activeList.push(p.label);
+            }
+        });
+
+        var risk = (1 - Math.exp(-BASELINE_HAZARD * hrProduct)) * 100;
+        return { risk: Math.round(risk * 100) / 100, factors: activeList };
+    }
+
+    function escapeHtml(str) {
+        var div = document.createElement('div');
+        div.appendChild(document.createTextNode(str));
+        return div.innerHTML;
+    }
+
+    function recalculate() {
+        var factors = getActiveFactors();
+
+        var blResult = calculateRisk(BLEEDING_PREDICTORS, factors);
+        var thResult = calculateRisk(THROMBOTIC_PREDICTORS, factors);
+
+        // Update numbers
+        document.getElementById('result-bleeding').textContent = blResult.risk.toFixed(2) + '%';
+        document.getElementById('result-thrombotic').textContent = thResult.risk.toFixed(2) + '%';
+
+        // Update progress bar
+        var total = blResult.risk + thResult.risk;
+        if (total > 0) {
+            var blPct = (blResult.risk / total) * 100;
+            document.getElementById('risk-bar-bleeding').style.width = blPct + '%';
+            document.getElementById('risk-bar-thrombotic').style.width = (100 - blPct) + '%';
+        }
+
+        // Update factor lists
+        var blList = document.getElementById('active-bleeding-factors');
+        var thList = document.getElementById('active-thrombotic-factors');
+
+        if (blResult.factors.length > 0) {
+            blList.innerHTML = blResult.factors.map(function (f) {
+                return '<li>' + escapeHtml(f) + '</li>';
+            }).join('');
+        } else {
+            blList.innerHTML = '<li class="text-muted">None</li>';
+        }
+
+        if (thResult.factors.length > 0) {
+            thList.innerHTML = thResult.factors.map(function (f) {
+                return '<li>' + escapeHtml(f) + '</li>';
+            }).join('');
+        } else {
+            thList.innerHTML = '<li class="text-muted">None</li>';
+        }
+
+        // Interpretation
+        var interpEl = document.getElementById('interpretation');
+        var interpText = document.getElementById('interpretation-text');
+
+        // Mortality-weighted comparison
+        var weightedBleeding = blResult.risk * MORTALITY_RATIO;
+
+        if (thResult.risk > weightedBleeding * 1.1) {
+            interpEl.className = 'alert alert-primary';
+            interpText.textContent = 'Ischemic risk dominates (' + thResult.risk.toFixed(1) +
+                '% MI/ST vs ' + blResult.risk.toFixed(1) +
+                '% bleeding). Consider extending/intensifying antithrombotic therapy.';
+        } else if (blResult.risk > thResult.risk * 1.1) {
+            interpEl.className = 'alert alert-danger';
+            interpText.textContent = 'Bleeding risk dominates (' + blResult.risk.toFixed(1) +
+                '% bleeding vs ' + thResult.risk.toFixed(1) +
+                '% MI/ST). Consider shortening/simplifying antithrombotic therapy.';
+        } else {
+            interpEl.className = 'alert alert-secondary';
+            interpText.textContent = 'Bleeding and ischemic risks are comparable (' +
+                blResult.risk.toFixed(1) + '% vs ' + thResult.risk.toFixed(1) +
+                '%). Standard guideline-based DAPT duration recommended.';
+        }
+    }
+
+    function init() {
+        // Bind all factor inputs
+        document.querySelectorAll('.tradeoff-factor').forEach(function (el) {
+            el.addEventListener('change', recalculate);
+        });
+
+        // Initial calculation
+        recalculate();
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/templates/standalone_calculator.html
+++ b/templates/standalone_calculator.html
@@ -1,0 +1,215 @@
+{% extends "layout.html" %}
+
+{% block title %}PRECISE-HBR Bleeding Risk Calculator{% endblock %}
+
+{% block content %}
+<div class="container mt-4" id="calculator-container">
+    <!-- Information Banner -->
+    <div class="alert alert-info mb-4" role="alert">
+        <div class="d-flex align-items-center">
+            <i class="fas fa-info-circle me-2" aria-hidden="true"></i>
+            <div class="flex-grow-1">
+                <strong>Disclaimer</strong> — This risk scoring tool is intended for use by clinicians, in conjunction
+                with individual patient assessment.
+                We assume no responsibility for how you use or interpret the PRECISE-HBR Score.
+            </div>
+            <div>
+                <a href="/docs" class="btn btn-sm btn-outline-secondary"
+                    aria-label="View documentation">
+                    <i class="fas fa-book" aria-hidden="true"></i> Documentation
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <!-- Total Score Display -->
+    <div class="card shadow-sm mb-4">
+        <div class="card-header bg-light d-flex justify-content-between align-items-center">
+            <h5 class="mb-0"><i class="fas fa-calculator"></i> PRECISE-HBR Bleeding Risk Score</h5>
+            <div>
+                <a href="/standalone" class="btn btn-sm btn-outline-primary me-2"
+                    aria-label="SMART on FHIR launch">
+                    <i class="fas fa-rocket" aria-hidden="true"></i> SMART Launch
+                </a>
+            </div>
+        </div>
+        <div class="card-body text-center">
+            <h1 id="total-score" class="display-3 fw-bold">2</h1>
+            <p id="risk-level" class="h4">
+                <span class="badge bg-success">Not high bleeding risk</span>
+                <small class="text-muted">(score &le;22)</small>
+            </p>
+            <p id="risk-percent" class="lead"></p>
+            <p id="recommendation" class="text-muted"></p>
+        </div>
+    </div>
+
+    <!-- Score Components -->
+    <div class="card shadow-sm mb-4">
+        <div class="card-header">
+            <h5 class="mb-0"><i class="fas fa-list-ul" aria-hidden="true"></i> Score Components</h5>
+        </div>
+        <div class="card-body">
+            <table class="table table-hover align-middle" role="table" aria-label="Risk score components">
+                <thead class="table-light">
+                    <tr>
+                        <th scope="col" style="width:35%">Risk Factor</th>
+                        <th scope="col" style="width:40%">Value</th>
+                        <th scope="col" style="width:10%">Score</th>
+                    </tr>
+                </thead>
+                <tbody id="score-components">
+                    <!-- Continuous factors -->
+                    <tr>
+                        <td><strong>Age</strong> <small class="text-muted">(years)</small></td>
+                        <td>
+                            <input type="number" class="form-control form-control-sm" id="input-age"
+                                   min="20" max="120" step="1" placeholder="e.g. 65"
+                                   aria-label="Age in years">
+                        </td>
+                        <td id="score-age" class="fw-bold">0</td>
+                    </tr>
+                    <tr>
+                        <td><strong>Hemoglobin</strong> <small class="text-muted">(g/dL)</small></td>
+                        <td>
+                            <input type="number" class="form-control form-control-sm" id="input-hb"
+                                   min="3" max="20" step="0.1" placeholder="e.g. 12.0"
+                                   aria-label="Hemoglobin in g/dL">
+                        </td>
+                        <td id="score-hb" class="fw-bold">0</td>
+                    </tr>
+                    <tr>
+                        <td><strong>eGFR</strong> <small class="text-muted">(mL/min/1.73m&sup2;)</small></td>
+                        <td>
+                            <input type="number" class="form-control form-control-sm" id="input-egfr"
+                                   min="1" max="200" step="1" placeholder="e.g. 60"
+                                   aria-label="eGFR in mL/min/1.73m2">
+                        </td>
+                        <td id="score-egfr" class="fw-bold">0</td>
+                    </tr>
+                    <tr>
+                        <td><strong>White Blood Cell Count</strong> <small class="text-muted">(&times;10&sup3;/&micro;L)</small></td>
+                        <td>
+                            <input type="number" class="form-control form-control-sm" id="input-wbc"
+                                   min="1" max="30" step="0.1" placeholder="e.g. 7.0"
+                                   aria-label="WBC in x10^3/uL">
+                        </td>
+                        <td id="score-wbc" class="fw-bold">0</td>
+                    </tr>
+                    <!-- Binary factors -->
+                    <tr>
+                        <td><strong>Previous Spontaneous Bleeding</strong></td>
+                        <td>
+                            <div class="form-check form-switch">
+                                <input class="form-check-input" type="checkbox" id="input-bleeding"
+                                       aria-label="Previous spontaneous bleeding">
+                                <label class="form-check-label" for="input-bleeding">Yes</label>
+                            </div>
+                        </td>
+                        <td id="score-bleeding" class="fw-bold">0</td>
+                    </tr>
+                    <tr>
+                        <td><strong>Long-term Oral Anticoagulation</strong></td>
+                        <td>
+                            <div class="form-check form-switch">
+                                <input class="form-check-input" type="checkbox" id="input-oac"
+                                       aria-label="Oral anticoagulation">
+                                <label class="form-check-label" for="input-oac">Yes</label>
+                            </div>
+                        </td>
+                        <td id="score-oac" class="fw-bold">0</td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <strong>ARC-HBR Factors &ge;1</strong>
+                            <br><small class="text-muted">Thrombocytopenia, bleeding diathesis, active malignancy,
+                                liver cirrhosis, recent major surgery/trauma, chronic NSAIDs/corticosteroids</small>
+                        </td>
+                        <td>
+                            <div class="form-check form-switch">
+                                <input class="form-check-input" type="checkbox" id="input-arc"
+                                       aria-label="ARC-HBR factors present">
+                                <label class="form-check-label" for="input-arc">Yes</label>
+                            </div>
+                        </td>
+                        <td id="score-arc" class="fw-bold">0</td>
+                    </tr>
+                </tbody>
+                <tfoot class="table-light">
+                    <tr>
+                        <td><strong>Base Score</strong></td>
+                        <td></td>
+                        <td class="fw-bold">2</td>
+                    </tr>
+                </tfoot>
+            </table>
+            <div class="form-text mt-2" role="note">
+                <i class="fas fa-info-circle" aria-hidden="true"></i>
+                Enter values to calculate the PRECISE-HBR bleeding risk score. The total score updates automatically.
+            </div>
+        </div>
+    </div>
+
+    <!-- Tradeoff Analysis Link -->
+    <div class="card shadow-sm mb-4 border-primary">
+        <div class="card-body">
+            <div class="d-flex align-items-center justify-content-between">
+                <div>
+                    <h5 class="mb-1"><i class="fas fa-balance-scale text-primary"></i> Bleeding vs. Thrombosis Tradeoff Analysis</h5>
+                    <p class="text-muted mb-0">
+                        Assess the individualized risk of BARC 3-5 bleeding vs. MI/stent thrombosis
+                        using the ARC-HBR tradeoff model.
+                    </p>
+                </div>
+                <a href="/standalone/tradeoff" class="btn btn-primary btn-lg">
+                    <i class="fas fa-arrow-right"></i> Tradeoff Calculator
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <!-- HBR Clinical Recommendations (shown when score >= 23) -->
+    <div class="d-none" id="hbr-recommendations-section">
+        <div class="alert alert-warning border-warning">
+            <h4 class="mb-3">
+                <i class="fas fa-exclamation-triangle text-warning"></i>
+                <strong>High Bleeding Risk (HBR) Detected</strong>
+            </h4>
+            <p class="mb-2">
+                Based on the PRECISE-HBR score (&ge;23), consider abbreviated DAPT or de-escalation strategies.
+                <strong>Always consult with the treating physician</strong> before making changes to antiplatelet therapy.
+            </p>
+        </div>
+    </div>
+
+    <!-- ARC-HBR Guideline Image -->
+    <div class="card shadow-sm mb-4">
+        <div class="card-header bg-light">
+            <h5 class="mb-0"><i class="fas fa-image"></i> ARC-HBR Guideline Reference</h5>
+        </div>
+        <div class="card-body text-center">
+            <img src="{{ url_for('static', filename='images/ARCHBR.png') }}" alt="ARC-HBR Guideline"
+                class="img-fluid" style="max-width:800px">
+        </div>
+    </div>
+
+    <!-- Citation -->
+    <div class="card shadow-sm mb-4">
+        <div class="card-header bg-light">
+            <h5 class="mb-0"><i class="fas fa-book"></i> Citation</h5>
+        </div>
+        <div class="card-body">
+            <p class="mb-1"><strong>Title:</strong> Derivation and Validation of the PRECISE-HBR Score to
+                Predict Bleeding After Percutaneous Coronary Intervention</p>
+            <p class="mb-1"><strong>Authors:</strong> Gragnano, Felice; van Klaveren, David; Heg, Dik; et al.</p>
+            <p class="mb-1"><strong>Journal:</strong> Circulation</p>
+            <p class="mb-1"><strong>DOI:</strong> <a href="https://doi.org/10.1161/CIRCULATIONAHA.124.072009"
+                    target="_blank" rel="noopener noreferrer">10.1161/CIRCULATIONAHA.124.072009</a></p>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script nonce="{{ csp_nonce() }}" src="{{ url_for('static', filename='js/standalone_calculator.js') }}"></script>
+{% endblock %}

--- a/templates/standalone_calculator.html
+++ b/templates/standalone_calculator.html
@@ -70,11 +70,18 @@
                         <td id="score-age" class="fw-bold">0</td>
                     </tr>
                     <tr>
-                        <td><strong>Hemoglobin</strong> <small class="text-muted">(g/dL)</small></td>
+                        <td><strong>Hemoglobin</strong> <small class="text-muted" id="hb-unit-label">(g/dL)</small></td>
                         <td>
-                            <input type="number" class="form-control form-control-sm" id="input-hb"
-                                   min="3" max="20" step="0.1" placeholder="e.g. 12.0"
-                                   aria-label="Hemoglobin in g/dL">
+                            <div class="input-group input-group-sm">
+                                <input type="number" class="form-control" id="input-hb"
+                                       min="3" max="20" step="0.1" placeholder="e.g. 12.0"
+                                       aria-label="Hemoglobin value">
+                                <span class="input-group-text" id="hb-unit-display">g/dL</span>
+                                <button class="btn btn-outline-secondary" type="button" id="hb-unit-toggle"
+                                        title="Toggle unit between g/dL and mmol/L">
+                                    <i class="fas fa-exchange-alt"></i>
+                                </button>
+                            </div>
                         </td>
                         <td id="score-hb" class="fw-bold">0</td>
                     </tr>

--- a/templates/standalone_calculator.html
+++ b/templates/standalone_calculator.html
@@ -34,8 +34,8 @@
             </div>
         </div>
         <div class="card-body text-center">
-            <h1 id="total-score" class="display-3 fw-bold">2</h1>
-            <p id="risk-level" class="h4">
+            <h1 id="total-score" class="display-3 fw-bold" aria-live="polite">2</h1>
+            <p id="risk-level" class="h4" aria-live="polite">
                 <span class="badge bg-success">Not high bleeding risk</span>
                 <small class="text-muted">(score &le;22)</small>
             </p>
@@ -146,7 +146,7 @@
                     <tr>
                         <td><strong>Base Score</strong></td>
                         <td></td>
-                        <td class="fw-bold">2</td>
+                        <td id="score-base" class="fw-bold">2</td>
                     </tr>
                 </tfoot>
             </table>

--- a/templates/standalone_tradeoff.html
+++ b/templates/standalone_tradeoff.html
@@ -106,7 +106,7 @@
                             <div class="card border-danger">
                                 <div class="card-body">
                                     <h6 class="text-muted">BARC 3-5 Bleeding</h6>
-                                    <h2 id="result-bleeding" class="text-danger fw-bold">1.40%</h2>
+                                    <h2 id="result-bleeding" class="text-danger fw-bold" aria-live="polite">1.40%</h2>
                                 </div>
                             </div>
                         </div>
@@ -114,7 +114,7 @@
                             <div class="card border-primary">
                                 <div class="card-body">
                                     <h6 class="text-muted">MI / Stent Thrombosis</h6>
-                                    <h2 id="result-thrombotic" class="text-primary fw-bold">1.40%</h2>
+                                    <h2 id="result-thrombotic" class="text-primary fw-bold" aria-live="polite">1.40%</h2>
                                 </div>
                             </div>
                         </div>
@@ -134,7 +134,7 @@
                     </div>
 
                     <!-- Interpretation -->
-                    <div id="interpretation" class="alert alert-info">
+                    <div id="interpretation" class="alert alert-info" aria-live="assertive">
                         <i class="fas fa-info-circle"></i>
                         <span id="interpretation-text">Enter risk factors to see the tradeoff analysis.</span>
                     </div>

--- a/templates/standalone_tradeoff.html
+++ b/templates/standalone_tradeoff.html
@@ -1,0 +1,185 @@
+{% extends "layout.html" %}
+
+{% block title %}ARC-HBR Bleeding vs. Thrombosis Tradeoff Calculator{% endblock %}
+
+{% block content %}
+<div class="container mt-4" id="tradeoff-container">
+    <!-- Back link -->
+    <div class="mb-3">
+        <a href="/" class="btn btn-outline-secondary btn-sm">
+            <i class="fas fa-arrow-left"></i> Back to PRECISE-HBR Calculator
+        </a>
+    </div>
+
+    <h2 class="mb-4"><i class="fas fa-balance-scale"></i> ARC-HBR Bleeding vs. Thrombosis Tradeoff</h2>
+
+    <div class="row">
+        <!-- Risk Factor Selection -->
+        <div class="col-md-5">
+            <div class="card shadow-sm mb-4">
+                <div class="card-header bg-primary text-white">
+                    <h5 class="mb-0">Risk Factors</h5>
+                </div>
+                <div class="card-body">
+                    <!-- Continuous factors mapped to categories -->
+                    <h6 class="text-muted mb-2">Demographics & Lab Values</h6>
+
+                    <div class="form-check form-switch mb-2">
+                        <input class="form-check-input tradeoff-factor" type="checkbox" id="tf-age_ge_65">
+                        <label class="form-check-label" for="tf-age_ge_65">Age &ge; 65 years</label>
+                    </div>
+
+                    <div class="mb-2">
+                        <label class="form-label mb-1"><small class="text-muted">Hemoglobin category:</small></label>
+                        <select class="form-select form-select-sm tradeoff-factor" id="tf-hb-select">
+                            <option value="normal" selected>Hb &ge; 13 g/dL (normal)</option>
+                            <option value="hemoglobin_11_12.9">Hb 11 &ndash; 12.9 g/dL</option>
+                            <option value="hemoglobin_lt_11">Hb &lt; 11 g/dL</option>
+                        </select>
+                    </div>
+
+                    <div class="mb-2">
+                        <label class="form-label mb-1"><small class="text-muted">eGFR category:</small></label>
+                        <select class="form-select form-select-sm tradeoff-factor" id="tf-egfr-select">
+                            <option value="normal" selected>eGFR &ge; 60 mL/min (normal)</option>
+                            <option value="egfr_30_59">eGFR 30 &ndash; 59 mL/min</option>
+                            <option value="egfr_lt_30">eGFR &lt; 30 mL/min</option>
+                        </select>
+                    </div>
+
+                    <hr>
+                    <h6 class="text-muted mb-2">Clinical Factors</h6>
+
+                    <div class="form-check form-switch mb-2">
+                        <input class="form-check-input tradeoff-factor" type="checkbox" id="tf-diabetes">
+                        <label class="form-check-label" for="tf-diabetes">Diabetes mellitus</label>
+                    </div>
+                    <div class="form-check form-switch mb-2">
+                        <input class="form-check-input tradeoff-factor" type="checkbox" id="tf-prior_mi">
+                        <label class="form-check-label" for="tf-prior_mi">Prior myocardial infarction</label>
+                    </div>
+                    <div class="form-check form-switch mb-2">
+                        <input class="form-check-input tradeoff-factor" type="checkbox" id="tf-smoker">
+                        <label class="form-check-label" for="tf-smoker">Current smoker</label>
+                    </div>
+                    <div class="form-check form-switch mb-2">
+                        <input class="form-check-input tradeoff-factor" type="checkbox" id="tf-nstemi_stemi">
+                        <label class="form-check-label" for="tf-nstemi_stemi">NSTEMI / STEMI presentation</label>
+                    </div>
+                    <div class="form-check form-switch mb-2">
+                        <input class="form-check-input tradeoff-factor" type="checkbox" id="tf-copd">
+                        <label class="form-check-label" for="tf-copd">COPD</label>
+                    </div>
+                    <div class="form-check form-switch mb-2">
+                        <input class="form-check-input tradeoff-factor" type="checkbox" id="tf-liver_cancer_surgery">
+                        <label class="form-check-label" for="tf-liver_cancer_surgery">Liver disease, cancer, or planned surgery</label>
+                    </div>
+
+                    <hr>
+                    <h6 class="text-muted mb-2">Procedure & Medication</h6>
+
+                    <div class="form-check form-switch mb-2">
+                        <input class="form-check-input tradeoff-factor" type="checkbox" id="tf-complex_pci">
+                        <label class="form-check-label" for="tf-complex_pci">Complex PCI procedure</label>
+                    </div>
+                    <div class="form-check form-switch mb-2">
+                        <input class="form-check-input tradeoff-factor" type="checkbox" id="tf-bms">
+                        <label class="form-check-label" for="tf-bms">Bare metal stent (BMS)</label>
+                    </div>
+                    <div class="form-check form-switch mb-2">
+                        <input class="form-check-input tradeoff-factor" type="checkbox" id="tf-oac_discharge">
+                        <label class="form-check-label" for="tf-oac_discharge">OAC at discharge</label>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Results -->
+        <div class="col-md-7">
+            <div class="card shadow-sm mb-4">
+                <div class="card-header bg-light">
+                    <h5 class="mb-0">1-Year Predicted Risk</h5>
+                </div>
+                <div class="card-body">
+                    <div class="row text-center mb-4">
+                        <div class="col-6">
+                            <div class="card border-danger">
+                                <div class="card-body">
+                                    <h6 class="text-muted">BARC 3-5 Bleeding</h6>
+                                    <h2 id="result-bleeding" class="text-danger fw-bold">1.40%</h2>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-6">
+                            <div class="card border-primary">
+                                <div class="card-body">
+                                    <h6 class="text-muted">MI / Stent Thrombosis</h6>
+                                    <h2 id="result-thrombotic" class="text-primary fw-bold">1.40%</h2>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Risk comparison bar -->
+                    <div class="mb-3">
+                        <div class="d-flex justify-content-between mb-1">
+                            <small class="text-danger fw-bold">Bleeding dominates</small>
+                            <small class="text-muted">Equal</small>
+                            <small class="text-primary fw-bold">Ischemia dominates</small>
+                        </div>
+                        <div class="progress" style="height: 24px;">
+                            <div id="risk-bar-bleeding" class="progress-bar bg-danger" style="width:50%"></div>
+                            <div id="risk-bar-thrombotic" class="progress-bar bg-primary" style="width:50%"></div>
+                        </div>
+                    </div>
+
+                    <!-- Interpretation -->
+                    <div id="interpretation" class="alert alert-info">
+                        <i class="fas fa-info-circle"></i>
+                        <span id="interpretation-text">Enter risk factors to see the tradeoff analysis.</span>
+                    </div>
+
+                    <!-- Active factors summary -->
+                    <div class="mt-3">
+                        <h6>Active Bleeding Factors:</h6>
+                        <ul id="active-bleeding-factors" class="mb-2"><li class="text-muted">None</li></ul>
+                        <h6>Active Thrombotic Factors:</h6>
+                        <ul id="active-thrombotic-factors" class="mb-2"><li class="text-muted">None</li></ul>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Clinical guidance -->
+            <div class="card shadow-sm mb-4">
+                <div class="card-header bg-light">
+                    <h5 class="mb-0"><i class="fas fa-stethoscope"></i> Clinical Interpretation</h5>
+                </div>
+                <div class="card-body">
+                    <ul class="mb-0">
+                        <li><strong>Ischemia &gt; Bleeding:</strong> Consider extending/intensifying antithrombotic therapy</li>
+                        <li><strong>Bleeding &gt; Ischemia:</strong> Consider shortening/simplifying antithrombotic therapy</li>
+                        <li><strong>Balanced:</strong> Standard guideline-based DAPT duration</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Citation -->
+    <div class="card shadow-sm mb-4">
+        <div class="card-header bg-light">
+            <h5 class="mb-0"><i class="fas fa-book"></i> Citation</h5>
+        </div>
+        <div class="card-body">
+            <p class="mb-1"><strong>Title:</strong> Assessing the Risks of Bleeding vs Thrombotic Events in Patients
+                at High Bleeding Risk After Coronary Stent Implantation: The ARC-High Bleeding Risk Trade-off Model</p>
+            <p class="mb-1"><strong>Authors:</strong> Urban P, Gregson J, Owen R, Mehran R, et al.</p>
+            <p class="mb-1"><strong>Journal:</strong> JAMA Cardiology, 2021;6(4):410-419</p>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script nonce="{{ csp_nonce() }}" src="{{ url_for('static', filename='js/standalone_tradeoff.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- 首頁 (`/`) 從 redirect to standalone launch 改為直接顯示 **PRECISE-HBR 獨立計算器**（無需登入、無需病人資料）
- 新增 `/standalone/tradeoff` **ARC-HBR 出血 vs 血栓 tradeoff 計算頁面**
- 前端即時計算，含 cloglog 風險曲線（PRECISE-HBR）和 Cox-PH 模型（tradeoff）
- 已登入用戶仍 redirect 到 `/main`（FHIR 版），`/standalone` (SMART Launch) 保留不動
- 全部 1003 項測試通過

## Test plan
- [x] `GET /` 回傳 200，顯示計算器 UI
- [x] `GET /standalone/tradeoff` 回傳 200，顯示 tradeoff UI
- [x] `GET /standalone` 仍顯示 SMART Launch 頁面
- [x] 完整測試套件 1003 passed, 0 failed
- [ ] CI pipeline 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)