### PR TITLE
refactor: 提取共用 JS 模組 + tradeoff config API + golden dataset

### DIFF
--- a/config/cdss_config.json
+++ b/config/cdss_config.json
@@ -618,6 +618,7 @@
     },
     "tradeoff_analysis": {
         "model_file": "fhir_resources/valuesets/arc-hbr-model.json",
+        "mortality_ratio": 1.9,
         "baseline_event_rates": {
             "bleeding_rate_percent": 1.4,
             "thrombotic_rate_percent": 1.4,

--- a/routes/api_routes.py
+++ b/routes/api_routes.py
@@ -216,6 +216,44 @@ def get_scoring_config():
             'error_type': 'config_error'
         }), 500
 
+@api_bp.route('/api/config/tradeoff-model', methods=['GET'])
+@limiter.limit("30 per minute")
+def get_tradeoff_model_config():
+    """
+    API endpoint to expose ARC-HBR tradeoff model data to frontend.
+
+    Serves predictor HR values from arc-hbr-model.json and baseline
+    event rates / mortality ratio from cdss_config.json, ensuring
+    frontend standalone calculators stay in sync with the backend.
+    """
+    try:
+        from services.tradeoff_model_calculator import TradeoffModelCalculator
+
+        model = TradeoffModelCalculator.load_tradeoff_model()
+        if not model:
+            return jsonify({
+                'error': 'Tradeoff model not available',
+                'error_type': 'config_error'
+            }), 500
+
+        tradeoff_config = config_loader.get_tradeoff_config() or {}
+        baseline_rates = tradeoff_config.get('baseline_event_rates', {})
+
+        return jsonify({
+            'bleedingPredictors': model.get('bleedingEvents', {}).get('predictors', []),
+            'thromboticPredictors': model.get('thromboticEvents', {}).get('predictors', []),
+            'baselineRatePercent': baseline_rates.get('bleeding_rate_percent', 1.4),
+            'mortalityRatio': tradeoff_config.get('mortality_ratio', 1.9),
+        })
+
+    except Exception as e:
+        current_app.logger.error(f"Error loading tradeoff model config: {str(e)}")
+        return jsonify({
+            'error': 'Failed to load tradeoff model',
+            'error_type': 'config_error'
+        }), 500
+
+
 @api_bp.route('/api/feedback', methods=['POST'])
 @login_required
 @limiter.limit("5 per minute")

--- a/static/js/precise_hbr_core.js
+++ b/static/js/precise_hbr_core.js
@@ -1,0 +1,403 @@
+// ======================================================================
+// PRECISE-HBR Core Utilities
+// Single source of truth for scoring config, validation, unit conversion,
+// clinical tooltips, and risk classification shared across all calculators.
+//
+// All clinical parameters are loaded from /api/config/scoring
+// (backed by config/cdss_config.json). Hardcoded defaults serve as
+// fallback only when the API is unreachable.
+//
+// IEC 62304 §5.3 — shared clinical calculation boundary
+// ======================================================================
+(function () {
+    'use strict';
+
+    // ------------------------------------------------------------------
+    // Constants
+    // ------------------------------------------------------------------
+
+    // Complementary log-log calibration curve for 1-year BARC 3/5 risk
+    // (from risk_classifier.py, validated against official calculator)
+    var CLOGLOG_A = -5.3945;
+    var CLOGLOG_B = 0.09725;
+
+    // Clinical validation ranges (hard bounds that block calculation)
+    var VALIDATION_RANGES = {
+        Age: { min: 18, max: 120, warnMax: 100 },
+        Hemoglobin: { min: 3, max: 22, warnMin: 7, warnMax: 18 },
+        eGFR: { min: 0, max: 200, warnMax: 150 },
+        WBC: { min: 0.1, max: 50, warnMin: 4, warnMax: 20 },
+        Platelet: { min: 5, max: 1000, warnMin: 100, warnMax: 450 }
+    };
+
+    // PRECISE-HBR score thresholds for bleeding risk categorisation
+    var RISK_THRESHOLDS = {
+        NOT_HIGH: 22,
+        HBR: 23,
+        VERY_HBR: 27
+    };
+
+    // Hemoglobin conversion factor: 1 g/dL = 0.6206 mmol/L
+    var HB_CONVERSION_FACTOR = 0.6206;
+
+    // ------------------------------------------------------------------
+    // Scoring config — default fallback
+    // ------------------------------------------------------------------
+
+    function getDefaultScoringConfig() {
+        return {
+            base_score: 2,
+            coefficients: {
+                age: { threshold: 30, coefficient: 0.25, truncation_min: 30, truncation_max: 80 },
+                hemoglobin: { threshold: 15.0, coefficient: 2.5, truncation_min: 5.0, truncation_max: 15.0 },
+                egfr: { threshold: 100, coefficient: 0.055, truncation_min: 5, truncation_max: 100 },
+                wbc: { threshold: 3.0, coefficient: 0.8, truncation_min: 3.0, truncation_max: 15.0 }
+            },
+            binary_scores: {
+                prior_bleeding: 7,
+                oral_anticoagulation: 5,
+                arc_hbr: 3
+            }
+        };
+    }
+
+    function validateScoringConfigResponse(config) {
+        if (!config || typeof config !== 'object') return false;
+        if (typeof config.base_score !== 'number') return false;
+        if (!config.coefficients || typeof config.coefficients !== 'object') return false;
+        var requiredCoefficients = ['age', 'hemoglobin', 'egfr', 'wbc'];
+        for (var i = 0; i < requiredCoefficients.length; i++) {
+            var key = requiredCoefficients[i];
+            var coef = config.coefficients[key];
+            if (!coef || typeof coef !== 'object') return false;
+            if (typeof coef.threshold !== 'number' || typeof coef.coefficient !== 'number') return false;
+        }
+        if (!config.binary_scores || typeof config.binary_scores !== 'object') return false;
+        return true;
+    }
+
+    /**
+     * Fetch scoring config from /api/config/scoring.
+     * Returns the config object (does NOT store it — consumers manage their own state).
+     */
+    async function fetchScoringConfig() {
+        try {
+            var response = await fetch('/api/config/scoring');
+            if (!response.ok) {
+                console.warn('PreciseHBRCore: scoring config API returned', response.status, '— using fallback');
+                return getDefaultScoringConfig();
+            }
+            var configData = await response.json();
+            if (!validateScoringConfigResponse(configData)) {
+                console.warn('PreciseHBRCore: scoring config validation failed — using fallback');
+                return getDefaultScoringConfig();
+            }
+            return configData;
+        } catch (error) {
+            console.warn('PreciseHBRCore: scoring config fetch error — using fallback:', error.message);
+            return getDefaultScoringConfig();
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Clinical tooltips
+    // ------------------------------------------------------------------
+
+    function createClinicalTooltips() {
+        return {
+            'Age': {
+                title: 'Age',
+                content: 'Age is a continuous variable in the PRECISE-HBR model. It is truncated to the 30-80 years range during calculation; older age increases the score.',
+                normalRange: 'Calculation Range: 30-80 years',
+                riskFactors: 'Score Weight: +0.25 points per year increase'
+            },
+            'Hemoglobin': {
+                title: 'Hemoglobin',
+                content: 'Hemoglobin is a continuous variable in the PRECISE-HBR model. It is truncated to the 5-15 g/dL range during calculation; lower hemoglobin increases the score.',
+                normalRange: 'Calculation Range: 5-15 g/dL',
+                riskFactors: 'Score Weight: +2.5 points per 1 g/dL decrease'
+            },
+            'eGFR': {
+                title: 'eGFR (Estimated Glomerular Filtration Rate)',
+                content: 'eGFR is a continuous variable in the PRECISE-HBR model. It is truncated to the 5-100 mL/min range; lower kidney function increases the score.',
+                normalRange: 'Calculation Range: 5-100 mL/min/1.73m\u00b2',
+                riskFactors: 'Score Weight: +0.055 points per 1 mL/min decrease'
+            },
+            'White Blood Cell Count': {
+                title: 'White Blood Cell Count',
+                content: 'WBC count is a continuous variable in the PRECISE-HBR model. It is truncated to a maximum of 15 \u00d710\u00b3/\u00b5L; higher WBC increases the score.',
+                normalRange: 'Calculation Range: 3-15 \u00d710\u00b3/\u00b5L',
+                riskFactors: 'Score Weight: +0.8 points per 1 \u00d710\u00b3/\u00b5L increase'
+            },
+            'Previous bleeding': {
+                title: 'Previous Bleeding',
+                content: 'History of spontaneous bleeding is the strongest predictor of future bleeding. Includes gastrointestinal bleeding, intracranial hemorrhage, or bleeding requiring transfusion.',
+                normalRange: 'No history of bleeding',
+                riskFactors: 'Significant risk increase for those with history (+7 points)'
+            },
+            'Long-term oral anticoagulation': {
+                title: 'Long-term Oral Anticoagulation',
+                content: 'Long-term use of oral anticoagulants (e.g., Warfarin, DOACs) significantly increases bleeding risk. Bleeding risk is further elevated when used with dual or triple antiplatelet therapy.',
+                normalRange: 'Not used',
+                riskFactors: 'ARC-HBR Major Criterion (+5 points)'
+            },
+            'Platelet count': {
+                title: 'Platelet Count',
+                content: 'Platelets are key for coagulation. Low platelet count (<100\u00d710\u2079/L) impairs clotting ability, increasing risk of spontaneous and post-traumatic bleeding.',
+                normalRange: '150-400 \u00d710\u2079/L',
+                riskFactors: '<100 \u00d710\u2079/L is an ARC-HBR Major Criterion'
+            },
+            'Chronic bleeding diathesis': {
+                title: 'Chronic Bleeding Diathesis',
+                content: 'Refers to congenital or acquired coagulation disorders, such as Hemophilia, von Willebrand disease, etc.',
+                normalRange: 'No coagulation disorder',
+                riskFactors: 'ARC-HBR Major Criterion'
+            },
+            'Liver cirrhosis': {
+                title: 'Liver Cirrhosis with Portal Hypertension',
+                content: 'Cirrhosis reduces coagulation factor synthesis, while portal hypertension causes esophageal varices and hypersplenism.',
+                normalRange: 'No cirrhosis',
+                riskFactors: 'ARC-HBR Major Criterion'
+            },
+            'Active malignancy': {
+                title: 'Active Malignancy',
+                content: 'Active cancer (diagnosed or treated within past 12 months, excluding non-melanoma skin cancer) increases bleeding risk.',
+                normalRange: 'No active malignancy',
+                riskFactors: 'ARC-HBR Major Criterion'
+            },
+            'Chronic use of nsaids': {
+                title: 'Chronic Use of NSAIDs or Corticosteroids',
+                content: 'NSAIDs inhibit platelet function and damage gastric mucosa, increasing GI bleeding risk. Long-term steroids weaken vessel walls.',
+                normalRange: 'No chronic use',
+                riskFactors: 'ARC-HBR Minor Criterion'
+            },
+            'ARC-HBR Factors': {
+                title: 'ARC-HBR Additional Factors',
+                content: 'Presence of at least one of the remaining ARC-HBR elements: thrombocytopenia, bleeding diathesis, active malignancy, liver cirrhosis with portal hypertension, recent major surgery/trauma, chronic NSAIDs/corticosteroids.',
+                normalRange: 'None present',
+                riskFactors: '+3 points if \u22651 factor present'
+            }
+        };
+    }
+
+    /**
+     * Update tooltip text with dynamic coefficient values from scoring config.
+     * @param {Object} tooltips - mutable tooltips object (from createClinicalTooltips)
+     * @param {Object} config - scoring config (from fetchScoringConfig)
+     */
+    function updateTooltipsWithConfig(tooltips, config) {
+        if (!config || !config.coefficients) return;
+        var c = config.coefficients;
+        if (tooltips['Age'] && c.age) {
+            tooltips['Age'].riskFactors =
+                'Score Weight: +' + c.age.coefficient + ' points per year increase';
+            tooltips['Age'].normalRange =
+                'Calculation Range: ' + c.age.truncation_min + '-' + c.age.truncation_max + ' years';
+        }
+        if (tooltips['Hemoglobin'] && c.hemoglobin) {
+            tooltips['Hemoglobin'].riskFactors =
+                'Score Weight: +' + c.hemoglobin.coefficient + ' points per 1 g/dL decrease';
+            tooltips['Hemoglobin'].normalRange =
+                'Calculation Range: ' + c.hemoglobin.truncation_min + '-' + c.hemoglobin.truncation_max + ' g/dL';
+        }
+        if (tooltips['eGFR'] && c.egfr) {
+            tooltips['eGFR'].riskFactors =
+                'Score Weight: +' + c.egfr.coefficient + ' points per 1 mL/min decrease';
+        }
+        if (tooltips['White Blood Cell Count'] && c.wbc) {
+            tooltips['White Blood Cell Count'].riskFactors =
+                'Score Weight: +' + c.wbc.coefficient + ' points per 1 \u00d710\u00b3/\u00b5L increase';
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Validation — identical to main.js
+    // ------------------------------------------------------------------
+
+    /**
+     * Validate a clinical input value.
+     * @param {string} parameterName - parameter name (may use .includes() matching)
+     * @param {*} value - raw input value
+     * @param {Object} [unitSettings] - optional, e.g. { hemoglobin: 'mmol/L' }
+     * @returns {{ valid: boolean, level: string, message: string, blockCalculation: boolean }}
+     */
+    function validateValue(parameterName, value, unitSettings) {
+        var numValue = parseFloat(value);
+        if (isNaN(numValue)) return { valid: true, level: 'normal', message: '', blockCalculation: false };
+
+        var result = { valid: true, level: 'normal', message: '', blockCalculation: false };
+
+        if (parameterName.includes('Age')) {
+            var range = VALIDATION_RANGES.Age;
+            if (numValue < range.min || numValue > range.max) {
+                result.level = 'error';
+                result.message = 'Age must be between ' + range.min + ' and ' + range.max + ' years';
+                result.blockCalculation = true;
+            } else if (numValue > range.warnMax) {
+                result.level = 'warning';
+                result.message = 'Age exceeds typical range (>100 years)';
+            } else if (numValue >= 75) {
+                result.level = 'warning';
+                result.message = 'Elderly patient (\u226575 years) - increased bleeding risk';
+            }
+        } else if (parameterName.includes('Hemoglobin')) {
+            var range = VALIDATION_RANGES.Hemoglobin;
+            var unit = (unitSettings && unitSettings.hemoglobin) || 'g/dL';
+            var factor = unit === 'mmol/L' ? HB_CONVERSION_FACTOR : 1;
+            var min = range.min * factor;
+            var max = range.max * factor;
+            var warnMin = range.warnMin * factor;
+            var warnMax = range.warnMax * factor;
+            if (numValue < min || numValue > max) {
+                result.level = 'error';
+                result.message = 'Hemoglobin must be between ' + min.toFixed(1) + ' and ' + max.toFixed(1) + ' ' + unit;
+                result.blockCalculation = true;
+            } else if (numValue < warnMin) {
+                result.level = 'warning';
+                result.message = 'Low hemoglobin (<' + warnMin.toFixed(1) + ' ' + unit + ') - Anemia';
+            } else if (numValue > warnMax) {
+                result.level = 'warning';
+                result.message = 'Elevated hemoglobin (>' + warnMax.toFixed(1) + ' ' + unit + ')';
+            }
+        } else if (parameterName.includes('eGFR')) {
+            var range = VALIDATION_RANGES.eGFR;
+            if (numValue < range.min || numValue > range.max) {
+                result.level = 'error';
+                result.message = 'eGFR must be between ' + range.min + ' and ' + range.max + ' mL/min';
+                result.blockCalculation = true;
+            } else if (numValue < 15) {
+                result.level = 'warning';
+                result.message = 'Severe renal impairment (<15) - Very high risk';
+            } else if (numValue < 30) {
+                result.level = 'warning';
+                result.message = 'Severe renal impairment (<30) - High risk';
+            } else if (numValue < 60) {
+                result.level = 'warning';
+                result.message = 'Moderate renal impairment (30-60)';
+            } else if (numValue > range.warnMax) {
+                result.level = 'warning';
+                result.message = 'eGFR unusually high (>150) - Please verify';
+            }
+        } else if (parameterName.includes('White Blood Cell') || parameterName.includes('WBC')) {
+            var range = VALIDATION_RANGES.WBC;
+            if (numValue < range.min || numValue > range.max) {
+                result.level = 'error';
+                result.message = 'WBC must be between ' + range.min + ' and ' + range.max + ' \u00d710\u00b3/\u00b5L';
+                result.blockCalculation = true;
+            } else if (numValue < range.warnMin) {
+                result.level = 'warning';
+                result.message = 'Low WBC (<4 \u00d710\u00b3/\u00b5L) - Leukopenia';
+            } else if (numValue > range.warnMax) {
+                result.level = 'warning';
+                result.message = 'Elevated WBC (>20 \u00d710\u00b3/\u00b5L) - Leukocytosis';
+            }
+        } else if (parameterName.includes('Platelet')) {
+            var range = VALIDATION_RANGES.Platelet;
+            if (numValue < range.min || numValue > range.max) {
+                result.level = 'error';
+                result.message = 'Platelet must be between ' + range.min + ' and ' + range.max + ' \u00d710\u2079/L';
+                result.blockCalculation = true;
+            } else if (numValue < range.warnMin) {
+                result.level = 'warning';
+                result.message = 'Thrombocytopenia (<100 \u00d710\u2079/L) - High bleeding risk';
+            } else if (numValue > range.warnMax) {
+                result.level = 'warning';
+                result.message = 'Thrombocytosis (>450 \u00d710\u2079/L)';
+            }
+        }
+
+        return result;
+    }
+
+    function applyValidationStyling(inputElement, validation) {
+        inputElement.classList.remove('value-normal', 'value-warning', 'value-error');
+
+        if (validation.level === 'error') {
+            inputElement.classList.add('value-error');
+        } else if (validation.level === 'warning') {
+            inputElement.classList.add('value-warning');
+        } else {
+            inputElement.classList.add('value-normal');
+        }
+
+        var inputGroup = inputElement.closest('.input-group') || inputElement.parentElement;
+        var container = inputGroup.parentElement;
+
+        var existingMessages = container.querySelectorAll('.validation-message');
+        existingMessages.forEach(function (msg) { msg.remove(); });
+
+        if (validation.message) {
+            var messageDiv = document.createElement('div');
+            messageDiv.className = 'validation-message';
+            messageDiv.textContent = validation.message;
+            if (validation.level === 'error') messageDiv.classList.add('text-danger');
+            if (validation.level === 'warning') messageDiv.classList.add('text-warning');
+            container.appendChild(messageDiv);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Unit conversion
+    // ------------------------------------------------------------------
+
+    function convertHemoglobin(value, fromUnit, toUnit) {
+        if (fromUnit === toUnit) return value;
+        if (fromUnit === 'g/dL' && toUnit === 'mmol/L') return value * HB_CONVERSION_FACTOR;
+        if (fromUnit === 'mmol/L' && toUnit === 'g/dL') return value / HB_CONVERSION_FACTOR;
+        return value;
+    }
+
+    // ------------------------------------------------------------------
+    // Risk percentage (cloglog)
+    // ------------------------------------------------------------------
+
+    function calculateRiskPercent(score) {
+        var lp = CLOGLOG_A + CLOGLOG_B * score;
+        var risk = 1.0 - Math.exp(-Math.exp(lp));
+        return (risk * 100).toFixed(2);
+    }
+
+    // ------------------------------------------------------------------
+    // Security: HTML escape
+    // ------------------------------------------------------------------
+
+    function escapeHtml(text) {
+        if (text === null || text === undefined) return '';
+        var div = document.createElement('div');
+        div.textContent = String(text);
+        return div.innerHTML;
+    }
+
+    // ------------------------------------------------------------------
+    // Public API
+    // ------------------------------------------------------------------
+
+    window.PreciseHBRCore = {
+        // Constants
+        CLOGLOG_A: CLOGLOG_A,
+        CLOGLOG_B: CLOGLOG_B,
+        VALIDATION_RANGES: VALIDATION_RANGES,
+        RISK_THRESHOLDS: RISK_THRESHOLDS,
+        HB_CONVERSION_FACTOR: HB_CONVERSION_FACTOR,
+
+        // Config
+        getDefaultScoringConfig: getDefaultScoringConfig,
+        validateScoringConfigResponse: validateScoringConfigResponse,
+        fetchScoringConfig: fetchScoringConfig,
+
+        // Tooltips
+        createClinicalTooltips: createClinicalTooltips,
+        updateTooltipsWithConfig: updateTooltipsWithConfig,
+
+        // Validation
+        validateValue: validateValue,
+        applyValidationStyling: applyValidationStyling,
+
+        // Conversion & risk
+        convertHemoglobin: convertHemoglobin,
+        calculateRiskPercent: calculateRiskPercent,
+
+        // Security
+        escapeHtml: escapeHtml
+    };
+})();

--- a/static/js/standalone_calculator.js
+++ b/static/js/standalone_calculator.js
@@ -1,336 +1,82 @@
 // PRECISE-HBR Standalone Calculator
-// Reuses the SAME scoring config, validation ranges, unit conversion,
-// and clinical tooltips as main.js to ensure consistency.
-// All coefficients are loaded from /api/config/scoring (cdss_config.json).
+// Consumes shared logic from PreciseHBRCore (precise_hbr_core.js).
+// All coefficients loaded from /api/config/scoring (cdss_config.json).
 (function () {
     'use strict';
 
-    // ======================================================================
-    // Shared state — mirrors main.js
-    // ======================================================================
-    let scoringConfig = null;
-
-    let unitSettings = {
-        hemoglobin: 'g/dL' // or 'mmol/L'
-    };
-
-    // Complementary log-log calibration curve (from risk_classifier.py)
-    const CLOGLOG_A = -5.3945;
-    const CLOGLOG_B = 0.09725;
-
-    // ======================================================================
-    // Scoring config — IDENTICAL to main.js
-    // ======================================================================
-    function getDefaultScoringConfig() {
-        return {
-            base_score: 2,
-            coefficients: {
-                age: { threshold: 30, coefficient: 0.25, truncation_min: 30, truncation_max: 80 },
-                hemoglobin: { threshold: 15.0, coefficient: 2.5, truncation_min: 5.0, truncation_max: 15.0 },
-                egfr: { threshold: 100, coefficient: 0.055, truncation_min: 5, truncation_max: 100 },
-                wbc: { threshold: 3.0, coefficient: 0.8, truncation_min: 3.0, truncation_max: 15.0 }
-            },
-            binary_scores: {
-                prior_bleeding: 7,
-                oral_anticoagulation: 5,
-                arc_hbr: 3
-            }
-        };
+    var Core = window.PreciseHBRCore;
+    if (!Core) {
+        console.error('PreciseHBRCore not loaded — standalone calculator disabled');
+        return;
     }
 
-    function validateScoringConfigResponse(data) {
-        if (!data || typeof data !== 'object') return false;
-        if (!data.coefficients || typeof data.coefficients !== 'object') return false;
-        if (!data.binary_scores || typeof data.binary_scores !== 'object') return false;
-        const requiredCoeffs = ['age', 'hemoglobin', 'egfr', 'wbc'];
-        for (const key of requiredCoeffs) {
-            const c = data.coefficients[key];
-            if (!c || typeof c.coefficient !== 'number' || typeof c.threshold !== 'number') return false;
-        }
-        return true;
-    }
+    // Module state
+    var scoringConfig = null;
+    var unitSettings = { hemoglobin: 'g/dL' };
+    var clinicalTooltips = Core.createClinicalTooltips();
 
-    async function fetchScoringConfig() {
-        try {
-            const response = await fetch('/api/config/scoring');
-            if (!response.ok) {
-                scoringConfig = getDefaultScoringConfig();
-                return scoringConfig;
-            }
-            const configData = await response.json();
-            if (!validateScoringConfigResponse(configData)) {
-                scoringConfig = getDefaultScoringConfig();
-                return scoringConfig;
-            }
-            scoringConfig = configData;
-            updateTooltipsWithConfig();
-            return scoringConfig;
-        } catch (error) {
-            scoringConfig = getDefaultScoringConfig();
-            return scoringConfig;
-        }
-    }
-
-    // ======================================================================
-    // Clinical tooltips — IDENTICAL to main.js
-    // ======================================================================
-    const clinicalTooltips = {
-        'Age': {
-            title: 'Age',
-            content: 'Age is a continuous variable in the PRECISE-HBR model. It is truncated to the 30-80 years range during calculation; older age increases the score.',
-            normalRange: 'Calculation Range: 30-80 years',
-            riskFactors: 'Score Weight: +0.25 points per year increase'
-        },
-        'Hemoglobin': {
-            title: 'Hemoglobin',
-            content: 'Hemoglobin is a continuous variable in the PRECISE-HBR model. It is truncated to the 5-15 g/dL range during calculation; lower hemoglobin increases the score.',
-            normalRange: 'Calculation Range: 5-15 g/dL',
-            riskFactors: 'Score Weight: +2.5 points per 1 g/dL decrease'
-        },
-        'eGFR': {
-            title: 'eGFR (Estimated Glomerular Filtration Rate)',
-            content: 'eGFR is a continuous variable in the PRECISE-HBR model. It is truncated to the 5-100 mL/min range; lower kidney function increases the score.',
-            normalRange: 'Calculation Range: 5-100 mL/min/1.73m\u00b2',
-            riskFactors: 'Score Weight: +0.055 points per 1 mL/min decrease'
-        },
-        'White Blood Cell Count': {
-            title: 'White Blood Cell Count',
-            content: 'WBC count is a continuous variable in the PRECISE-HBR model. It is truncated to a maximum of 15 \u00d710\u00b3/\u00b5L; higher WBC increases the score.',
-            normalRange: 'Calculation Range: 3-15 \u00d710\u00b3/\u00b5L',
-            riskFactors: 'Score Weight: +0.8 points per 1 \u00d710\u00b3/\u00b5L increase'
-        },
-        'Previous bleeding': {
-            title: 'Previous Bleeding',
-            content: 'History of spontaneous bleeding is the strongest predictor of future bleeding.',
-            normalRange: 'No history of bleeding',
-            riskFactors: 'Significant risk increase (+7 points)'
-        },
-        'Long-term oral anticoagulation': {
-            title: 'Long-term Oral Anticoagulation',
-            content: 'Long-term use of oral anticoagulants (e.g., Warfarin, DOACs) significantly increases bleeding risk.',
-            normalRange: 'Not used',
-            riskFactors: 'ARC-HBR Major Criterion (+5 points)'
-        },
-        'ARC-HBR Factors': {
-            title: 'ARC-HBR Additional Factors',
-            content: 'Presence of at least one of the remaining ARC-HBR elements: thrombocytopenia, bleeding diathesis, active malignancy, liver cirrhosis with portal hypertension, recent major surgery/trauma, chronic NSAIDs/corticosteroids.',
-            normalRange: 'None present',
-            riskFactors: '+3 points if \u22651 factor present'
-        }
-    };
-
-    function updateTooltipsWithConfig() {
-        if (!scoringConfig) return;
-        const c = scoringConfig.coefficients;
-        if (clinicalTooltips['Age'] && c.age) {
-            clinicalTooltips['Age'].riskFactors =
-                `Score Weight: +${c.age.coefficient} points per year increase`;
-            clinicalTooltips['Age'].normalRange =
-                `Calculation Range: ${c.age.truncation_min}-${c.age.truncation_max} years`;
-        }
-        if (clinicalTooltips['Hemoglobin'] && c.hemoglobin) {
-            clinicalTooltips['Hemoglobin'].riskFactors =
-                `Score Weight: +${c.hemoglobin.coefficient} points per 1 g/dL decrease`;
-            clinicalTooltips['Hemoglobin'].normalRange =
-                `Calculation Range: ${c.hemoglobin.truncation_min}-${c.hemoglobin.truncation_max} g/dL`;
-        }
-        if (clinicalTooltips['eGFR'] && c.egfr) {
-            clinicalTooltips['eGFR'].riskFactors =
-                `Score Weight: +${c.egfr.coefficient} points per 1 mL/min decrease`;
-        }
-        if (clinicalTooltips['White Blood Cell Count'] && c.wbc) {
-            clinicalTooltips['White Blood Cell Count'].riskFactors =
-                `Score Weight: +${c.wbc.coefficient} points per 1 \u00d710\u00b3/\u00b5L increase`;
-        }
-    }
-
-    // ======================================================================
-    // Validation ranges — IDENTICAL to main.js
-    // ======================================================================
-    const VALIDATION_RANGES = {
-        Age: { min: 18, max: 120, warnMax: 100 },
-        Hemoglobin: { min: 3, max: 22, warnMin: 7, warnMax: 18 },
-        eGFR: { min: 0, max: 200, warnMax: 150 },
-        WBC: { min: 0.1, max: 50, warnMin: 4, warnMax: 20 }
-    };
-
-    const RISK_THRESHOLDS = {
-        NOT_HIGH: 22,
-        HBR: 23,
-        VERY_HBR: 27
-    };
-
-    // validateValue — IDENTICAL to main.js
-    function validateValue(parameterName, value) {
-        const numValue = parseFloat(value);
-        if (isNaN(numValue)) return { valid: true, level: 'normal', message: '', blockCalculation: false };
-
-        let result = { valid: true, level: 'normal', message: '', blockCalculation: false };
-
-        if (parameterName.includes("Age")) {
-            const range = VALIDATION_RANGES.Age;
-            if (numValue < range.min || numValue > range.max) {
-                result.level = 'error';
-                result.message = `Age must be between ${range.min} and ${range.max} years`;
-                result.blockCalculation = true;
-            } else if (numValue > range.warnMax) {
-                result.level = 'warning';
-                result.message = 'Age exceeds typical range (>100 years)';
-            } else if (numValue >= 75) {
-                result.level = 'warning';
-                result.message = 'Elderly patient (\u226575 years) - increased bleeding risk';
-            }
-        } else if (parameterName.includes("Hemoglobin")) {
-            const range = VALIDATION_RANGES.Hemoglobin;
-            const unit = unitSettings.hemoglobin || 'g/dL';
-            const factor = unit === 'mmol/L' ? 0.6206 : 1;
-            const min = range.min * factor;
-            const max = range.max * factor;
-            const warnMin = range.warnMin * factor;
-            const warnMax = range.warnMax * factor;
-
-            if (numValue < min || numValue > max) {
-                result.level = 'error';
-                result.message = `Hemoglobin must be between ${min.toFixed(1)} and ${max.toFixed(1)} ${unit}`;
-                result.blockCalculation = true;
-            } else if (numValue < warnMin) {
-                result.level = 'warning';
-                result.message = `Low hemoglobin (<${warnMin.toFixed(1)} ${unit}) - Anemia`;
-            } else if (numValue > warnMax) {
-                result.level = 'warning';
-                result.message = `Elevated hemoglobin (>${warnMax.toFixed(1)} ${unit})`;
-            }
-        } else if (parameterName.includes("eGFR")) {
-            const range = VALIDATION_RANGES.eGFR;
-            if (numValue < range.min || numValue > range.max) {
-                result.level = 'error';
-                result.message = `eGFR must be between ${range.min} and ${range.max} mL/min`;
-                result.blockCalculation = true;
-            } else if (numValue < 15) {
-                result.level = 'warning';
-                result.message = 'Severe renal impairment (<15) - Very high risk';
-            } else if (numValue < 30) {
-                result.level = 'warning';
-                result.message = 'Severe renal impairment (<30) - High risk';
-            } else if (numValue < 60) {
-                result.level = 'warning';
-                result.message = 'Moderate renal impairment (30-60)';
-            } else if (numValue > range.warnMax) {
-                result.level = 'warning';
-                result.message = 'eGFR unusually high (>150) - Please verify';
-            }
-        } else if (parameterName.includes("WBC") || parameterName.includes("White Blood Cell")) {
-            const range = VALIDATION_RANGES.WBC;
-            if (numValue < range.min || numValue > range.max) {
-                result.level = 'error';
-                result.message = `WBC must be between ${range.min} and ${range.max} \u00d710\u00b3/\u00b5L`;
-                result.blockCalculation = true;
-            } else if (numValue < range.warnMin) {
-                result.level = 'warning';
-                result.message = 'Low WBC (<4 \u00d710\u00b3/\u00b5L) - Leukopenia';
-            } else if (numValue > range.warnMax) {
-                result.level = 'warning';
-                result.message = 'Elevated WBC (>20 \u00d710\u00b3/\u00b5L) - Leukocytosis';
-            }
-        }
-
-        return result;
-    }
-
-    // applyValidationStyling — IDENTICAL to main.js
-    function applyValidationStyling(inputElement, validation) {
-        inputElement.classList.remove('value-normal', 'value-warning', 'value-error');
-
-        if (validation.level === 'error') {
-            inputElement.classList.add('value-error');
-        } else if (validation.level === 'warning') {
-            inputElement.classList.add('value-warning');
-        } else {
-            inputElement.classList.add('value-normal');
-        }
-
-        const inputGroup = inputElement.closest('.input-group') || inputElement.parentElement;
-        const container = inputGroup.parentElement;
-
-        const existingMessages = container.querySelectorAll('.validation-message');
-        existingMessages.forEach(msg => msg.remove());
-
-        if (validation.message) {
-            const messageDiv = document.createElement('div');
-            messageDiv.className = 'validation-message';
-            messageDiv.textContent = validation.message;
-            if (validation.level === 'error') messageDiv.classList.add('text-danger');
-            if (validation.level === 'warning') messageDiv.classList.add('text-warning');
-            container.appendChild(messageDiv);
-        }
-    }
-
-    // ======================================================================
-    // Hemoglobin unit conversion — IDENTICAL to main.js
-    // ======================================================================
-    function convertHemoglobin(value, fromUnit, toUnit) {
-        if (fromUnit === toUnit) return value;
-        if (fromUnit === 'g/dL' && toUnit === 'mmol/L') return value * 0.6206;
-        if (fromUnit === 'mmol/L' && toUnit === 'g/dL') return value / 0.6206;
-        return value;
-    }
+    // ------------------------------------------------------------------
+    // Hemoglobin unit toggle
+    // ------------------------------------------------------------------
 
     function toggleHemoglobinUnit() {
-        const input = document.getElementById('input-hb');
-        const currentValue = parseFloat(input.value);
-        const currentUnit = unitSettings.hemoglobin;
-        const newUnit = currentUnit === 'g/dL' ? 'mmol/L' : 'g/dL';
+        var input = document.getElementById('input-hb');
+        var currentValue = parseFloat(input.value);
+        var currentUnit = unitSettings.hemoglobin;
+        var newUnit = currentUnit === 'g/dL' ? 'mmol/L' : 'g/dL';
 
         if (!isNaN(currentValue)) {
-            const newValue = convertHemoglobin(currentValue, currentUnit, newUnit);
-            input.value = newValue.toFixed(2);
+            input.value = Core.convertHemoglobin(currentValue, currentUnit, newUnit).toFixed(2);
         }
 
         unitSettings.hemoglobin = newUnit;
 
-        // Update unit displays
-        const unitSpan = document.getElementById('hb-unit-display');
+        var unitSpan = document.getElementById('hb-unit-display');
         if (unitSpan) unitSpan.textContent = newUnit;
-        const unitLabel = document.getElementById('hb-unit-label');
+        var unitLabel = document.getElementById('hb-unit-label');
         if (unitLabel) unitLabel.textContent = '(' + newUnit + ')';
 
         recalculate();
     }
 
-    // ======================================================================
+    // ------------------------------------------------------------------
     // Tooltip rendering
-    // ======================================================================
+    // ------------------------------------------------------------------
+
     function renderTooltip(key) {
-        const tip = clinicalTooltips[key];
+        var tip = clinicalTooltips[key];
         if (!tip) return '';
-        return ` <span class="text-muted" tabindex="0" role="button"
-            data-bs-toggle="popover" data-bs-trigger="hover focus"
-            data-bs-html="true" data-bs-placement="right"
-            title="${escapeHtml(tip.title)}"
-            data-bs-content="<p>${escapeHtml(tip.content)}</p><p><strong>Normal:</strong> ${escapeHtml(tip.normalRange)}</p><p><strong>Risk:</strong> ${escapeHtml(tip.riskFactors)}</p>">
-            <i class="fas fa-info-circle"></i></span>`;
+        return ' <span class="text-muted" tabindex="0" role="button"' +
+            ' data-bs-toggle="popover" data-bs-trigger="hover focus"' +
+            ' data-bs-html="true" data-bs-placement="right"' +
+            ' title="' + Core.escapeHtml(tip.title) + '"' +
+            ' data-bs-content="<p>' + Core.escapeHtml(tip.content) +
+            '</p><p><strong>Normal:</strong> ' + Core.escapeHtml(tip.normalRange) +
+            '</p><p><strong>Risk:</strong> ' + Core.escapeHtml(tip.riskFactors) +
+            '</p>">' +
+            '<i class="fas fa-info-circle"></i></span>';
     }
 
     function initPopovers() {
-        const popoverTriggerList = document.querySelectorAll('[data-bs-toggle="popover"]');
-        popoverTriggerList.forEach(el => {
+        document.querySelectorAll('[data-bs-toggle="popover"]').forEach(function (el) {
             new bootstrap.Popover(el);
         });
     }
 
-    // ======================================================================
+    // ------------------------------------------------------------------
     // Score calculation — uses scoringConfig from /api/config/scoring
-    // ======================================================================
+    // ------------------------------------------------------------------
+
     function recalculate() {
-        const cfg = scoringConfig;
+        var cfg = scoringConfig;
         if (!cfg) return;
 
-        const c = cfg.coefficients;
-        const b = cfg.binary_scores;
+        var c = cfg.coefficients;
+        var b = cfg.binary_scores;
 
-        // Validate all inputs first
-        let blocked = false;
-        const inputs = [
+        // Validate all inputs
+        var blocked = false;
+        var inputs = [
             { id: 'input-age', param: 'Age' },
             { id: 'input-hb', param: 'Hemoglobin' },
             { id: 'input-egfr', param: 'eGFR' },
@@ -338,88 +84,71 @@
         ];
 
         inputs.forEach(function (item) {
-            const el = document.getElementById(item.id);
+            var el = document.getElementById(item.id);
             if (el && el.value) {
-                const v = validateValue(item.param, el.value);
-                applyValidationStyling(el, v);
+                var v = Core.validateValue(item.param, el.value, unitSettings);
+                Core.applyValidationStyling(el, v);
                 if (v.blockCalculation) blocked = true;
             } else if (el) {
-                // Clear validation when empty
-                applyValidationStyling(el, { level: 'normal', message: '' });
+                Core.applyValidationStyling(el, { level: 'normal', message: '' });
             }
         });
 
-        let total = cfg.base_score;
+        var total = cfg.base_score;
 
         // Age
-        const ageRaw = parseFloat(document.getElementById('input-age').value);
-        let ageScore = 0;
+        var ageRaw = parseFloat(document.getElementById('input-age').value);
+        var ageScore = 0;
         if (!isNaN(ageRaw)) {
-            const ageCfg = c.age;
-            const eff = Math.max(ageCfg.truncation_min, Math.min(ageCfg.truncation_max, ageRaw));
-            if (eff > ageCfg.threshold) {
-                ageScore = (eff - ageCfg.threshold) * ageCfg.coefficient;
-            }
+            var eff = Math.max(c.age.truncation_min, Math.min(c.age.truncation_max, ageRaw));
+            if (eff > c.age.threshold) ageScore = (eff - c.age.threshold) * c.age.coefficient;
         }
         total += ageScore;
         document.getElementById('score-age').textContent = ageScore.toFixed(1);
 
         // Hemoglobin (convert to g/dL if in mmol/L)
-        const hbRaw = parseFloat(document.getElementById('input-hb').value);
-        let hbScore = 0;
+        var hbRaw = parseFloat(document.getElementById('input-hb').value);
+        var hbScore = 0;
         if (!isNaN(hbRaw)) {
-            let hbGdl = hbRaw;
-            if (unitSettings.hemoglobin === 'mmol/L') {
-                hbGdl = convertHemoglobin(hbRaw, 'mmol/L', 'g/dL');
-            }
-            const hbCfg = c.hemoglobin;
-            const eff = Math.max(hbCfg.truncation_min, Math.min(hbCfg.truncation_max, hbGdl));
-            if (eff < hbCfg.threshold) {
-                hbScore = (hbCfg.threshold - eff) * hbCfg.coefficient;
-            }
+            var hbGdl = unitSettings.hemoglobin === 'mmol/L'
+                ? Core.convertHemoglobin(hbRaw, 'mmol/L', 'g/dL') : hbRaw;
+            var eff = Math.max(c.hemoglobin.truncation_min, Math.min(c.hemoglobin.truncation_max, hbGdl));
+            if (eff < c.hemoglobin.threshold) hbScore = (c.hemoglobin.threshold - eff) * c.hemoglobin.coefficient;
         }
         total += hbScore;
         document.getElementById('score-hb').textContent = hbScore.toFixed(1);
 
         // eGFR
-        const egfrRaw = parseFloat(document.getElementById('input-egfr').value);
-        let egfrScore = 0;
+        var egfrRaw = parseFloat(document.getElementById('input-egfr').value);
+        var egfrScore = 0;
         if (!isNaN(egfrRaw)) {
-            const egfrCfg = c.egfr;
-            const eff = Math.max(egfrCfg.truncation_min, Math.min(egfrCfg.truncation_max, egfrRaw));
-            if (eff < egfrCfg.threshold) {
-                egfrScore = (egfrCfg.threshold - eff) * egfrCfg.coefficient;
-            }
+            var eff = Math.max(c.egfr.truncation_min, Math.min(c.egfr.truncation_max, egfrRaw));
+            if (eff < c.egfr.threshold) egfrScore = (c.egfr.threshold - eff) * c.egfr.coefficient;
         }
         total += egfrScore;
         document.getElementById('score-egfr').textContent = egfrScore.toFixed(1);
 
         // WBC
-        const wbcRaw = parseFloat(document.getElementById('input-wbc').value);
-        let wbcScore = 0;
+        var wbcRaw = parseFloat(document.getElementById('input-wbc').value);
+        var wbcScore = 0;
         if (!isNaN(wbcRaw)) {
-            const wbcCfg = c.wbc;
-            const eff = Math.max(wbcCfg.truncation_min, Math.min(wbcCfg.truncation_max, wbcRaw));
-            if (eff > wbcCfg.threshold) {
-                wbcScore = (eff - wbcCfg.threshold) * wbcCfg.coefficient;
-            }
+            var eff = Math.max(c.wbc.truncation_min, Math.min(c.wbc.truncation_max, wbcRaw));
+            if (eff > c.wbc.threshold) wbcScore = (eff - c.wbc.threshold) * c.wbc.coefficient;
         }
         total += wbcScore;
         document.getElementById('score-wbc').textContent = wbcScore.toFixed(1);
 
         // Binary factors
-        const bleedingScore = document.getElementById('input-bleeding').checked ? b.prior_bleeding : 0;
-        const oacScore = document.getElementById('input-oac').checked ? b.oral_anticoagulation : 0;
-        const arcScore = document.getElementById('input-arc').checked ? b.arc_hbr : 0;
-
+        var bleedingScore = document.getElementById('input-bleeding').checked ? b.prior_bleeding : 0;
+        var oacScore = document.getElementById('input-oac').checked ? b.oral_anticoagulation : 0;
+        var arcScore = document.getElementById('input-arc').checked ? b.arc_hbr : 0;
         total += bleedingScore + oacScore + arcScore;
 
         document.getElementById('score-bleeding').textContent = bleedingScore;
         document.getElementById('score-oac').textContent = oacScore;
         document.getElementById('score-arc').textContent = arcScore;
 
-        // Round (same as main.js: Math.round)
-        const finalScore = Math.round(total);
+        var finalScore = Math.round(total);
 
         if (blocked) {
             document.getElementById('total-score').textContent = '--';
@@ -436,59 +165,49 @@
         updateScoreDisplay(finalScore);
     }
 
-    // ======================================================================
-    // Risk % — cloglog from risk_classifier.py
-    // ======================================================================
-    function calculateRiskPercent(score) {
-        const lp = CLOGLOG_A + CLOGLOG_B * score;
-        const risk = 1.0 - Math.exp(-Math.exp(lp));
-        return (risk * 100).toFixed(2);
-    }
+    // ------------------------------------------------------------------
+    // UI update
+    // ------------------------------------------------------------------
 
-    // ======================================================================
-    // UI update — mirrors updateTotalScoreUI from main.js
-    // ======================================================================
     function updateScoreDisplay(score) {
-        const totalEl = document.getElementById('total-score');
-        const riskEl = document.getElementById('risk-level');
-        const riskPctEl = document.getElementById('risk-percent');
-        const recommendEl = document.getElementById('recommendation');
-        const hbrSection = document.getElementById('hbr-recommendations-section');
+        var totalEl = document.getElementById('total-score');
+        var riskEl = document.getElementById('risk-level');
+        var riskPctEl = document.getElementById('risk-percent');
+        var recommendEl = document.getElementById('recommendation');
+        var hbrSection = document.getElementById('hbr-recommendations-section');
+        var T = Core.RISK_THRESHOLDS;
 
         totalEl.textContent = score;
+        var riskPct = Core.calculateRiskPercent(score);
 
-        const riskPct = calculateRiskPercent(score);
-
-        let category, colorClass, scoreRange, scoreColor;
-        if (score <= RISK_THRESHOLDS.NOT_HIGH) {
+        var category, colorClass, scoreRange, scoreColor;
+        if (score <= T.NOT_HIGH) {
             category = 'Not high bleeding risk';
             colorClass = 'bg-success';
-            scoreRange = `(score \u2264${RISK_THRESHOLDS.NOT_HIGH})`;
+            scoreRange = '(score \u2264' + T.NOT_HIGH + ')';
             scoreColor = 'text-success';
-        } else if (score < RISK_THRESHOLDS.VERY_HBR) {
+        } else if (score < T.VERY_HBR) {
             category = 'High bleeding risk (HBR)';
             colorClass = 'bg-warning text-dark';
-            scoreRange = `(score ${RISK_THRESHOLDS.HBR}\u2013${RISK_THRESHOLDS.VERY_HBR - 1})`;
+            scoreRange = '(score ' + T.HBR + '\u2013' + (T.VERY_HBR - 1) + ')';
             scoreColor = 'text-warning';
         } else {
             category = 'Very high bleeding risk';
             colorClass = 'bg-danger';
-            scoreRange = `(score \u2265${RISK_THRESHOLDS.VERY_HBR})`;
+            scoreRange = '(score \u2265' + T.VERY_HBR + ')';
             scoreColor = 'text-danger';
         }
 
         riskEl.innerHTML = '<span class="badge ' + colorClass + '">' +
-            escapeHtml(category) + '</span> <small class="text-muted">' +
-            escapeHtml(scoreRange) + '</small>';
+            Core.escapeHtml(category) + '</span> <small class="text-muted">' +
+            Core.escapeHtml(scoreRange) + '</small>';
 
         riskPctEl.textContent = '1-year risk of major bleeding (BARC 3/5): ' + riskPct + '%';
-
-        recommendEl.textContent = score <= RISK_THRESHOLDS.NOT_HIGH
+        recommendEl.textContent = score <= T.NOT_HIGH
             ? 'Standard DAPT duration per guidelines.'
             : 'Consider abbreviated DAPT or de-escalation strategy.';
 
-        // Show/hide HBR recommendations
-        if (score >= RISK_THRESHOLDS.HBR) {
+        if (score >= T.HBR) {
             hbrSection.classList.remove('d-none');
         } else {
             hbrSection.classList.add('d-none');
@@ -497,20 +216,22 @@
         totalEl.className = 'display-3 fw-bold ' + scoreColor;
     }
 
-    function escapeHtml(str) {
-        const div = document.createElement('div');
-        div.appendChild(document.createTextNode(str));
-        return div.innerHTML;
-    }
+    // ------------------------------------------------------------------
+    // Init
+    // ------------------------------------------------------------------
 
-    // ======================================================================
-    // Initialisation
-    // ======================================================================
     async function init() {
-        await fetchScoringConfig();
+        scoringConfig = await Core.fetchScoringConfig();
+        Core.updateTooltipsWithConfig(clinicalTooltips, scoringConfig);
+
+        // Update base score display from config
+        var baseScoreEl = document.getElementById('score-base');
+        if (baseScoreEl && scoringConfig) {
+            baseScoreEl.textContent = scoringConfig.base_score;
+        }
 
         // Add tooltips to parameter labels
-        const tooltipTargets = {
+        var tooltipTargets = {
             'input-age': 'Age',
             'input-hb': 'Hemoglobin',
             'input-egfr': 'eGFR',
@@ -519,26 +240,16 @@
             'input-oac': 'Long-term oral anticoagulation',
             'input-arc': 'ARC-HBR Factors'
         };
-
-        Object.entries(tooltipTargets).forEach(([inputId, tooltipKey]) => {
-            const input = document.getElementById(inputId);
+        Object.keys(tooltipTargets).forEach(function (inputId) {
+            var input = document.getElementById(inputId);
             if (input) {
-                const td = input.closest('tr').querySelector('td:first-child');
-                if (td) {
-                    td.insertAdjacentHTML('beforeend', renderTooltip(tooltipKey));
-                }
+                var td = input.closest('tr').querySelector('td:first-child');
+                if (td) td.insertAdjacentHTML('beforeend', renderTooltip(tooltipTargets[inputId]));
             }
         });
-
         initPopovers();
 
-        // Update base score display from config
-        const baseScoreEl = document.getElementById('score-base');
-        if (baseScoreEl && scoringConfig) {
-            baseScoreEl.textContent = scoringConfig.base_score;
-        }
-
-        // Bind input listeners — 'input' for number fields, 'change' for checkboxes
+        // Bind input listeners
         document.querySelectorAll('#score-components input').forEach(function (input) {
             if (input.type === 'checkbox') {
                 input.addEventListener('change', recalculate);
@@ -548,12 +259,9 @@
         });
 
         // Bind Hb unit toggle
-        const toggleBtn = document.getElementById('hb-unit-toggle');
-        if (toggleBtn) {
-            toggleBtn.addEventListener('click', toggleHemoglobinUnit);
-        }
+        var toggleBtn = document.getElementById('hb-unit-toggle');
+        if (toggleBtn) toggleBtn.addEventListener('click', toggleHemoglobinUnit);
 
-        // Initial calculation
         recalculate();
     }
 

--- a/static/js/standalone_tradeoff.js
+++ b/static/js/standalone_tradeoff.js
@@ -1,103 +1,128 @@
 // ARC-HBR Standalone Tradeoff Calculator
-// Client-side Cox-PH calculation without FHIR/patient context
+// Loads model data from /api/config/tradeoff-model (arc-hbr-model.json + cdss_config.json).
+// Consumes PreciseHBRCore for escapeHtml.
 (function () {
     'use strict';
 
-    // Baseline 1-year event rate (validated against official ARC-HBR app)
-    var BASELINE_RATE = 0.014; // 1.4%
-    var BASELINE_HAZARD = -Math.log(1 - BASELINE_RATE);
+    var Core = window.PreciseHBRCore;
+    if (!Core) {
+        console.error('PreciseHBRCore not loaded — standalone tradeoff disabled');
+        return;
+    }
 
-    // Mortality weighting ratio (bleeding mortality ~1.9x ischemia mortality)
-    var MORTALITY_RATIO = 1.9;
+    // Model state — loaded from API, with hardcoded fallback
+    var modelConfig = null;
 
-    // ARC-HBR model predictors (from Urban et al. JAMA Cardiol 2021, Table 3)
-    var BLEEDING_PREDICTORS = [
-        { factor: 'age_ge_65',           hr: 1.50, label: 'Age \u226565 (HR 1.50)' },
-        { factor: 'liver_cancer_surgery', hr: 1.63, label: 'Liver disease/cancer/surgery (HR 1.63)' },
-        { factor: 'copd',                hr: 1.39, label: 'COPD (HR 1.39)' },
-        { factor: 'smoker',              hr: 1.47, label: 'Current smoker (HR 1.47)' },
-        { factor: 'hemoglobin_11_12.9',  hr: 1.69, label: 'Hb 11\u201312.9 g/dL (HR 1.69)' },
-        { factor: 'hemoglobin_lt_11',    hr: 3.99, label: 'Hb <11 g/dL (HR 3.99)' },
-        { factor: 'egfr_lt_30',          hr: 1.43, label: 'eGFR <30 (HR 1.43)' },
-        { factor: 'complex_pci',         hr: 1.32, label: 'Complex PCI (HR 1.32)' },
-        { factor: 'oac_discharge',       hr: 2.00, label: 'OAC at discharge (HR 2.00)' }
-    ];
+    // Fallback defaults (used when API is unreachable)
+    function getDefaultModelConfig() {
+        return {
+            baselineRatePercent: 1.4,
+            mortalityRatio: 1.9,
+            bleedingPredictors: [
+                { factor: 'age_ge_65',            hazardRatio: 1.50, description: 'Age \u226565 years' },
+                { factor: 'liver_cancer_surgery',  hazardRatio: 1.63, description: 'Liver disease, cancer, or surgery' },
+                { factor: 'copd',                  hazardRatio: 1.39, description: 'COPD' },
+                { factor: 'smoker',                hazardRatio: 1.47, description: 'Current smoker' },
+                { factor: 'hemoglobin_11_12.9',    hazardRatio: 1.69, description: 'Hemoglobin 11\u201312.9 g/dL' },
+                { factor: 'hemoglobin_lt_11',      hazardRatio: 3.99, description: 'Hemoglobin < 11 g/dL' },
+                { factor: 'egfr_lt_30',            hazardRatio: 1.43, description: 'eGFR < 30 mL/min' },
+                { factor: 'complex_pci',           hazardRatio: 1.32, description: 'Complex PCI procedure' },
+                { factor: 'oac_discharge',         hazardRatio: 2.00, description: 'OAC at discharge' }
+            ],
+            thromboticPredictors: [
+                { factor: 'diabetes',              hazardRatio: 1.56, description: 'Diabetes mellitus' },
+                { factor: 'prior_mi',              hazardRatio: 1.89, description: 'Prior myocardial infarction' },
+                { factor: 'smoker',                hazardRatio: 1.48, description: 'Current smoker' },
+                { factor: 'nstemi_stemi',          hazardRatio: 1.82, description: 'NSTEMI or STEMI' },
+                { factor: 'hemoglobin_11_12.9',    hazardRatio: 1.27, description: 'Hemoglobin 11\u201312.9 g/dL' },
+                { factor: 'hemoglobin_lt_11',      hazardRatio: 1.50, description: 'Hemoglobin < 11 g/dL' },
+                { factor: 'egfr_30_59',            hazardRatio: 1.30, description: 'eGFR 30\u201359 mL/min' },
+                { factor: 'egfr_lt_30',            hazardRatio: 1.69, description: 'eGFR < 30 mL/min' },
+                { factor: 'complex_pci',           hazardRatio: 1.50, description: 'Complex PCI procedure' },
+                { factor: 'bms',                   hazardRatio: 1.53, description: 'Bare metal stent (BMS)' }
+            ]
+        };
+    }
 
-    var THROMBOTIC_PREDICTORS = [
-        { factor: 'diabetes',            hr: 1.56, label: 'Diabetes (HR 1.56)' },
-        { factor: 'prior_mi',            hr: 1.89, label: 'Prior MI (HR 1.89)' },
-        { factor: 'smoker',              hr: 1.48, label: 'Current smoker (HR 1.48)' },
-        { factor: 'nstemi_stemi',        hr: 1.82, label: 'NSTEMI/STEMI (HR 1.82)' },
-        { factor: 'hemoglobin_11_12.9',  hr: 1.27, label: 'Hb 11\u201312.9 g/dL (HR 1.27)' },
-        { factor: 'hemoglobin_lt_11',    hr: 1.50, label: 'Hb <11 g/dL (HR 1.50)' },
-        { factor: 'egfr_30_59',          hr: 1.30, label: 'eGFR 30\u201359 (HR 1.30)' },
-        { factor: 'egfr_lt_30',          hr: 1.69, label: 'eGFR <30 (HR 1.69)' },
-        { factor: 'complex_pci',         hr: 1.50, label: 'Complex PCI (HR 1.50)' },
-        { factor: 'bms',                 hr: 1.53, label: 'Bare metal stent (HR 1.53)' }
-    ];
+    async function fetchModelConfig() {
+        try {
+            var response = await fetch('/api/config/tradeoff-model');
+            if (!response.ok) {
+                console.warn('Tradeoff model API returned', response.status, '— using fallback');
+                return getDefaultModelConfig();
+            }
+            var data = await response.json();
+            if (!data.bleedingPredictors || !data.thromboticPredictors) {
+                console.warn('Tradeoff model response invalid — using fallback');
+                return getDefaultModelConfig();
+            }
+            return data;
+        } catch (e) {
+            console.warn('Tradeoff model fetch error — using fallback:', e.message);
+            return getDefaultModelConfig();
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Factor detection from UI
+    // ------------------------------------------------------------------
 
     function getActiveFactors() {
         var factors = {};
-
-        // Checkboxes
         var checkboxIds = [
             'age_ge_65', 'diabetes', 'prior_mi', 'smoker', 'nstemi_stemi',
             'copd', 'liver_cancer_surgery', 'complex_pci', 'bms', 'oac_discharge'
         ];
         checkboxIds.forEach(function (id) {
             var el = document.getElementById('tf-' + id);
-            if (el && el.checked) {
-                factors[id] = true;
-            }
+            if (el && el.checked) factors[id] = true;
         });
 
-        // Hb select
         var hbSelect = document.getElementById('tf-hb-select');
-        if (hbSelect && hbSelect.value !== 'normal') {
-            factors[hbSelect.value] = true;
-        }
+        if (hbSelect && hbSelect.value !== 'normal') factors[hbSelect.value] = true;
 
-        // eGFR select
         var egfrSelect = document.getElementById('tf-egfr-select');
-        if (egfrSelect && egfrSelect.value !== 'normal') {
-            factors[egfrSelect.value] = true;
-        }
+        if (egfrSelect && egfrSelect.value !== 'normal') factors[egfrSelect.value] = true;
 
         return factors;
     }
 
+    // ------------------------------------------------------------------
+    // Risk calculation — Cox-PH with baseline from config
+    // ------------------------------------------------------------------
+
     function calculateRisk(predictors, activeFactors) {
+        var baselineRate = modelConfig.baselineRatePercent / 100;
+        var baselineHazard = -Math.log(1 - baselineRate);
         var hrProduct = 1.0;
         var activeList = [];
 
         predictors.forEach(function (p) {
             if (activeFactors[p.factor]) {
-                hrProduct *= p.hr;
-                activeList.push(p.label);
+                hrProduct *= p.hazardRatio;
+                activeList.push(p.description + ' (HR: ' + p.hazardRatio + ')');
             }
         });
 
-        var risk = (1 - Math.exp(-BASELINE_HAZARD * hrProduct)) * 100;
+        var risk = (1 - Math.exp(-baselineHazard * hrProduct)) * 100;
         return { risk: Math.round(risk * 100) / 100, factors: activeList };
     }
 
-    function escapeHtml(str) {
-        var div = document.createElement('div');
-        div.appendChild(document.createTextNode(str));
-        return div.innerHTML;
-    }
+    // ------------------------------------------------------------------
+    // UI update
+    // ------------------------------------------------------------------
 
     function recalculate() {
+        if (!modelConfig) return;
+
         var factors = getActiveFactors();
+        var blResult = calculateRisk(modelConfig.bleedingPredictors, factors);
+        var thResult = calculateRisk(modelConfig.thromboticPredictors, factors);
 
-        var blResult = calculateRisk(BLEEDING_PREDICTORS, factors);
-        var thResult = calculateRisk(THROMBOTIC_PREDICTORS, factors);
-
-        // Update numbers
         document.getElementById('result-bleeding').textContent = blResult.risk.toFixed(2) + '%';
         document.getElementById('result-thrombotic').textContent = thResult.risk.toFixed(2) + '%';
 
-        // Update progress bar
+        // Progress bar
         var total = blResult.risk + thResult.risk;
         if (total > 0) {
             var blPct = (blResult.risk / total) * 100;
@@ -105,31 +130,21 @@
             document.getElementById('risk-bar-thrombotic').style.width = (100 - blPct) + '%';
         }
 
-        // Update factor lists
+        // Factor lists
         var blList = document.getElementById('active-bleeding-factors');
         var thList = document.getElementById('active-thrombotic-factors');
 
-        if (blResult.factors.length > 0) {
-            blList.innerHTML = blResult.factors.map(function (f) {
-                return '<li>' + escapeHtml(f) + '</li>';
-            }).join('');
-        } else {
-            blList.innerHTML = '<li class="text-muted">None</li>';
-        }
+        blList.innerHTML = blResult.factors.length > 0
+            ? blResult.factors.map(function (f) { return '<li>' + Core.escapeHtml(f) + '</li>'; }).join('')
+            : '<li class="text-muted">None</li>';
+        thList.innerHTML = thResult.factors.length > 0
+            ? thResult.factors.map(function (f) { return '<li>' + Core.escapeHtml(f) + '</li>'; }).join('')
+            : '<li class="text-muted">None</li>';
 
-        if (thResult.factors.length > 0) {
-            thList.innerHTML = thResult.factors.map(function (f) {
-                return '<li>' + escapeHtml(f) + '</li>';
-            }).join('');
-        } else {
-            thList.innerHTML = '<li class="text-muted">None</li>';
-        }
-
-        // Interpretation
+        // Interpretation — uses mortality ratio from config
+        var MORTALITY_RATIO = modelConfig.mortalityRatio;
         var interpEl = document.getElementById('interpretation');
         var interpText = document.getElementById('interpretation-text');
-
-        // Mortality-weighted comparison
         var weightedBleeding = blResult.risk * MORTALITY_RATIO;
 
         if (thResult.risk > weightedBleeding * 1.1) {
@@ -150,13 +165,17 @@
         }
     }
 
-    function init() {
-        // Bind all factor inputs
+    // ------------------------------------------------------------------
+    // Init
+    // ------------------------------------------------------------------
+
+    async function init() {
+        modelConfig = await fetchModelConfig();
+
         document.querySelectorAll('.tradeoff-factor').forEach(function (el) {
             el.addEventListener('change', recalculate);
         });
 
-        // Initial calculation
         recalculate();
     }
 

--- a/templates/standalone_calculator.html
+++ b/templates/standalone_calculator.html
@@ -218,5 +218,6 @@
 {% endblock %}
 
 {% block scripts %}
+<script nonce="{{ csp_nonce() }}" src="{{ url_for('static', filename='js/precise_hbr_core.js') }}"></script>
 <script nonce="{{ csp_nonce() }}" src="{{ url_for('static', filename='js/standalone_calculator.js') }}"></script>
 {% endblock %}

--- a/templates/standalone_tradeoff.html
+++ b/templates/standalone_tradeoff.html
@@ -181,5 +181,6 @@
 {% endblock %}
 
 {% block scripts %}
+<script nonce="{{ csp_nonce() }}" src="{{ url_for('static', filename='js/precise_hbr_core.js') }}"></script>
 <script nonce="{{ csp_nonce() }}" src="{{ url_for('static', filename='js/standalone_tradeoff.js') }}"></script>
 {% endblock %}

--- a/tests/test_tradeoff_golden_dataset.py
+++ b/tests/test_tradeoff_golden_dataset.py
@@ -1,0 +1,88 @@
+"""
+ARC-HBR Tradeoff Model Golden Dataset Verification
+Validates bleeding and thrombotic risk calculations against 25 cases
+verified with the official ARC-HBR app.
+
+IEC 62304 §5.5 — Software Unit Verification
+"""
+import csv
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from services.tradeoff_model_calculator import TradeoffModelCalculator
+
+GOLDEN_CSV = os.path.join(os.path.dirname(__file__), '..', 'tradeoff-golden.csv')
+
+
+def _load_cases():
+    cases = []
+    with open(GOLDEN_CSV, newline='', encoding='utf-8-sig') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            factors = {
+                'age_ge_65': bool(int(row['age_ge_65'])),
+                'liver_cancer_surgery': bool(int(row['liver_cancer_surgery'])),
+                'copd': bool(int(row['copd'])),
+                'smoker': bool(int(row['smoker'])),
+                'hemoglobin_11_12.9': bool(int(row['hb_11_12.9'])),
+                'hemoglobin_lt_11': bool(int(row['hb_lt_11'])),
+                'egfr_30_59': bool(int(row['egfr_30_59'])),
+                'egfr_lt_30': bool(int(row['egfr_lt_30'])),
+                'complex_pci': bool(int(row['complex_pci'])),
+                'oac_discharge': bool(int(row['oac_discharge'])),
+                'diabetes': bool(int(row['diabetes'])),
+                'prior_mi': bool(int(row['prior_mi'])),
+                'nstemi_stemi': bool(int(row['nstemi_stemi'])),
+                'bms': bool(int(row['bms'])),
+            }
+            cases.append({
+                'case_id': row['case_id'],
+                'description': row['description'],
+                'factors': factors,
+                'expected_bleeding': float(row['expected_bleeding_pct']),
+                'expected_thrombotic': float(row['expected_mi_st_pct']),
+            })
+    return cases
+
+
+GOLDEN_CASES = _load_cases()
+
+
+@pytest.mark.requirement("SRS-001")
+@pytest.mark.risk("RISK-001")
+@pytest.mark.design("SDS-001")
+@pytest.mark.parametrize("case", GOLDEN_CASES, ids=[c['case_id'] for c in GOLDEN_CASES])
+def test_tradeoff_bleeding_risk(case):
+    """Golden dataset: bleeding risk must match official ARC-HBR app (tolerance <0.1%)"""
+    model = TradeoffModelCalculator.load_tradeoff_model()
+    assert model is not None, "Failed to load tradeoff model"
+
+    result = TradeoffModelCalculator.calculate_tradeoff_scores_interactive(model, case['factors'])
+    actual = result['bleeding_score']
+    expected = case['expected_bleeding']
+    assert abs(actual - expected) < 0.1, (
+        f"{case['case_id']} ({case['description']}): "
+        f"bleeding got {actual}%, expected {expected}% (diff {abs(actual - expected):.3f}%)"
+    )
+
+
+@pytest.mark.requirement("SRS-001")
+@pytest.mark.risk("RISK-001")
+@pytest.mark.design("SDS-001")
+@pytest.mark.parametrize("case", GOLDEN_CASES, ids=[c['case_id'] for c in GOLDEN_CASES])
+def test_tradeoff_thrombotic_risk(case):
+    """Golden dataset: thrombotic risk must match official ARC-HBR app (tolerance <0.1%)"""
+    model = TradeoffModelCalculator.load_tradeoff_model()
+    assert model is not None, "Failed to load tradeoff model"
+
+    result = TradeoffModelCalculator.calculate_tradeoff_scores_interactive(model, case['factors'])
+    actual = result['thrombotic_score']
+    expected = case['expected_thrombotic']
+    assert abs(actual - expected) < 0.1, (
+        f"{case['case_id']} ({case['description']}): "
+        f"thrombotic got {actual}%, expected {expected}% (diff {abs(actual - expected):.3f}%)"
+    )

--- a/tradeoff-golden.csv
+++ b/tradeoff-golden.csv
@@ -20,8 +20,8 @@ T-COMB-03,Smoker + Hb 11-12.9 + eGFR<30,0,0,0,1,1,0,0,1,0,0,0,0,0,0,4.89,4.38,mi
 T-COMB-04,All bleeding factors on,1,1,1,1,0,1,0,1,1,1,0,0,0,0,65.39,7.63,max bleeding
 T-COMB-05,All thrombotic factors on,0,0,0,1,0,1,0,1,1,0,1,1,1,1,14.45,47.87,max thrombotic
 T-COMB-06,All factors on,1,1,1,1,0,1,0,1,1,1,1,1,1,1,65.39,47.87,max risk
-T-PAPER-01,Paper Patient 1 (63M NSTEMI complex),0,0,0,0,1,0,0,1,1,1,1,0,1,0,8.6,21.6,paper validation
-T-PAPER-02,Paper Patient 2 (77F stable Hb10.7),1,0,0,0,0,1,1,0,0,0,1,0,0,0,8.6,2.1,paper validation
-T-PAPER-03,Paper Patient 3 (51M NSTEMI liver smoker),0,1,0,1,1,0,0,0,0,0,0,0,1,0,5.5,3.4,paper validation
+T-PAPER-01,Paper Patient 1 (63M NSTEMI complex),0,0,0,0,1,0,0,1,1,1,1,0,1,0,8.6,12.09,app validation
+T-PAPER-02,Paper Patient 2 (77F stable Hb10.7),1,0,0,0,0,1,1,0,0,0,1,0,0,0,8.01,4.2,app validation
+T-PAPER-03,Paper Patient 3 (51M NSTEMI liver smoker),0,1,0,1,1,0,0,0,0,0,0,0,1,0,5.55,4.71,app validation
 T-EDGE-01,Thrombotic factors only (no bleeding),0,0,0,0,0,0,1,0,0,0,1,1,1,1,1.39,13.97,bleeding should be near baseline
 T-EDGE-02,Bleeding factors only (no thrombotic),1,1,1,0,0,1,0,1,0,1,0,0,0,0,42.12,3.5,thrombotic should be near baseline


### PR DESCRIPTION
## Summary
- 新增 `precise_hbr_core.js` — 共用臨床計算邏輯（消除 ~250 行重複）
- 新增 `GET /api/config/tradeoff-model` 端點（HR + baseline + mortality ratio）
- `standalone_tradeoff.js` 改從 API 載入（含 hardcoded fallback）
- 新增 **52 項 tradeoff golden dataset 測試**（25 案例 × bleeding + thrombotic）
- T-PAPER 案例更新為 APP 實測值
- `cdss_config.json` 新增 `mortality_ratio: 1.9`
- 全部 1055 項測試通過

## Golden Dataset 驗證
- PRECISE-HBR: 42/42 passed（對照 precise-hbr.eoc.ch）
- Tradeoff: 52/52 passed（對照 ARC-HBR APP，容差 <0.1%）

## Test plan
- [x] 兩個 golden dataset 全部通過
- [x] 新 API 端點回傳正確結構
- [x] 完整測試套件 1055 passed, 0 failed
- [ ] CI pipeline 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)