### PR TITLE
fix: tradeoff 圖表刻度對齊論文 (1.25%-80%)

### DIFF
--- a/routes/web_routes.py
+++ b/routes/web_routes.py
@@ -125,3 +125,4 @@ def submit_complaint():
                              error="An error occurred while submitting your complaint. Please try again."), 500
 
 
+

--- a/templates/tradeoff_analysis.html
+++ b/templates/tradeoff_analysis.html
@@ -358,7 +358,7 @@
             // Based on JAMA Cardiology paper: mortality ratio is 1.9x higher after MI/ST vs bleeding
             const MORTALITY_RATIO = 1.9; // From paper: MI/ST mortality vs bleeding mortality ratio
             const HBR_THRESHOLD = 4.0;   // High Bleeding Risk threshold (4% per year, ARC-HBR criteria)
-            const MIN_LOG_VALUE = 0.1;   // Minimum value for logarithmic scale
+            const MIN_LOG_VALUE = 1.25;  // Minimum value for logarithmic scale (matches JAMA paper)
 
             // === Security: HTML escape utility to prevent XSS ===
             function escapeHtml(text) {
@@ -720,18 +720,24 @@
                             scales: {
                                 x: {
                                     type: 'logarithmic',
-                                    title: { display: true, text: 'Estimated 1-Year Bleeding Risk (BARC 3-5, %)' },
-                                    min: 0.1, max: 50,
+                                    title: { display: true, text: 'Predicted 1-y risk of BARC types 3 to 5 bleeding, %' },
+                                    min: 1.25, max: 80,
                                     ticks: {
-                                        callback: function (value, index, values) { return Number(value.toString()); }
+                                        callback: function (value) {
+                                            var allowed = [1.25, 2.5, 5, 10, 20, 50, 80];
+                                            return allowed.includes(value) ? value : '';
+                                        }
                                     }
                                 },
                                 y: {
                                     type: 'logarithmic',
-                                    title: { display: true, text: 'Estimated 1-Year Ischemic Risk (MI/ST, %)' },
-                                    min: 0.1, max: 50,
+                                    title: { display: true, text: 'Predicted 1-y risk of MI and/or ST, %' },
+                                    min: 1.25, max: 80,
                                     ticks: {
-                                        callback: function (value, index, values) { return Number(value.toString()); }
+                                        callback: function (value) {
+                                            var allowed = [1.25, 2.5, 5, 10, 20, 50, 80];
+                                            return allowed.includes(value) ? value : '';
+                                        }
                                     }
                                 }
                             },


### PR DESCRIPTION
## Summary
- X/Y 軸範圍從 0.1-50% 改為 **1.25-80%**（與 JAMA Cardiol 論文 Figure 一致）
- 刻度標記：1.25, 2.5, 5, 10, 20, 50, 80
- MIN_LOG_VALUE 從 0.1 改為 1.25（baseline 1.4% 以下無法到達）
- 兩軸對稱，trade-off 線呈正確 45 度角
- 1055 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)