### PR TITLE
fix: resolve index redirect loop and tradeoff CSP violations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 
 ## [Unreleased]
 
+### 修復 (Bug Fixes)
+- **修復首頁 redirect loop** — 當 session 存在但 token 已過期時，`/` 路由的 `is_session_valid()` 僅檢查 key 存在，導致 redirect 到 `/main` → `login_required` 偵測 token 過期 → redirect 回 `/` → 無限循環。修復：`/` 路由新增 `is_token_expired()` + `try_server_side_refresh()` 檢查，token 無法刷新時清除 stale session，直接顯示 standalone calculator
+- **修復 standalone tradeoff CSP `style-src` 違規** — `standalone_tradeoff.html` 進度條使用 inline `style="height: 24px;"` 和 `style="width:50%"`，加上 `standalone_tradeoff.js` 的 `element.style.width = ...` 動態更新，全部被 CSP `style-src` 策略阻擋：
+  - 靜態 inline style 改為 nonce'd `<style>` block 中的 CSS class（`.progress-h24`、`.risk-bar-init`）
+  - JS 動態寬度更新改用 CSP-safe helper（`_cspSetBarWidths`），透過 nonce'd `<style>` 元素更新 CSS rule
+
 ### 計算校正 (Calculation Calibration) — Class C
 - **PRECISE-HBR eGFR 係數校正**（PR #54）— 從 0.05 調整為 **0.055**，經官方計算器 (precise-hbr.eoc.ch) API 系統性驗證，修正極端 eGFR 值的 1 分偏差
 - **1 年出血風險百分比改用 complementary log-log (cloglog) 校正曲線**（PR #54）：

--- a/routes/web_routes.py
+++ b/routes/web_routes.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, render_template, request, redirect, url_for, session, jsonify, current_app
 from markupsafe import escape
-from utils.web_utils import is_session_valid, login_required, render_error_page
+from utils.web_utils import is_session_valid, is_token_expired, try_server_side_refresh, login_required, render_error_page
 from services.audit_logger import audit_ephi_access
 from extensions import limiter
 import random
@@ -14,7 +14,10 @@ web_bp = Blueprint('web', __name__)
 @web_bp.route('/')
 def index():
     if is_session_valid():
-        return redirect(url_for('web.main_page'))
+        if not is_token_expired() or try_server_side_refresh():
+            return redirect(url_for('web.main_page'))
+        # Stale session — clear it and show standalone page
+        session.clear()
     return render_template('standalone_calculator.html')
 
 @web_bp.route('/standalone')

--- a/static/js/standalone_tradeoff.js
+++ b/static/js/standalone_tradeoff.js
@@ -126,8 +126,9 @@
         var total = blResult.risk + thResult.risk;
         if (total > 0) {
             var blPct = (blResult.risk / total) * 100;
-            document.getElementById('risk-bar-bleeding').style.width = blPct + '%';
-            document.getElementById('risk-bar-thrombotic').style.width = (100 - blPct) + '%';
+            if (window._cspSetBarWidths) {
+                window._cspSetBarWidths('risk-bar-bleeding', blPct, 'risk-bar-thrombotic', 100 - blPct);
+            }
         }
 
         // Factor lists

--- a/templates/standalone_tradeoff.html
+++ b/templates/standalone_tradeoff.html
@@ -3,6 +3,10 @@
 {% block title %}ARC-HBR Bleeding vs. Thrombosis Tradeoff Calculator{% endblock %}
 
 {% block content %}
+<style nonce="{{ csp_nonce() }}">
+.progress-h24 { height: 24px; }
+.risk-bar-init { width: 50%; }
+</style>
 <div class="container mt-4" id="tradeoff-container">
     <!-- Back link -->
     <div class="mb-3">
@@ -127,9 +131,9 @@
                             <small class="text-muted">Equal</small>
                             <small class="text-primary fw-bold">Ischemia dominates</small>
                         </div>
-                        <div class="progress" style="height: 24px;">
-                            <div id="risk-bar-bleeding" class="progress-bar bg-danger" style="width:50%"></div>
-                            <div id="risk-bar-thrombotic" class="progress-bar bg-primary" style="width:50%"></div>
+                        <div class="progress progress-h24">
+                            <div id="risk-bar-bleeding" class="progress-bar bg-danger risk-bar-init"></div>
+                            <div id="risk-bar-thrombotic" class="progress-bar bg-primary risk-bar-init"></div>
                         </div>
                     </div>
 
@@ -183,4 +187,18 @@
 {% block scripts %}
 <script nonce="{{ csp_nonce() }}" src="{{ url_for('static', filename='js/precise_hbr_core.js') }}"></script>
 <script nonce="{{ csp_nonce() }}" src="{{ url_for('static', filename='js/standalone_tradeoff.js') }}"></script>
+<script nonce="{{ csp_nonce() }}">
+// CSP-safe dynamic style helper: creates a nonce'd <style> element for JS-driven width updates
+(function() {
+    var sheet = document.createElement('style');
+    sheet.setAttribute('nonce', '{{ csp_nonce() }}');
+    document.head.appendChild(sheet);
+    window._cspSetWidth = function(id, pct) {
+        sheet.textContent = '#' + id + '{width:' + pct + '%}';
+    };
+    window._cspSetBarWidths = function(bleedId, bleedPct, thromId, thromPct) {
+        sheet.textContent = '#' + bleedId + '{width:' + bleedPct + '%} #' + thromId + '{width:' + thromPct + '%}';
+    };
+})();
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- **Fix redirect loop on `/`**: When a stale session exists with an expired token, the index route now checks `is_token_expired()` + attempts `try_server_side_refresh()` before redirecting to `/main`. If refresh fails, clears the session and shows the standalone calculator — breaking the `/` → `/main` → `/` infinite redirect loop.
- **Fix CSP `style-src` violations on tradeoff page**: Replaced inline `style=` attributes with nonce'd CSS classes (`.progress-h24`, `.risk-bar-init`), and replaced JS `element.style.width` with a CSP-safe `_cspSetBarWidths()` helper that updates widths via a nonce'd dynamic stylesheet.

## Regulatory Traceability
- **Implements**: N/A (bug fix)
- **Mitigates**: RISK-002 (authentication/session handling), RISK-005 (CSP security headers)
- **Change Classification**: Class A (no clinical impact — UI/auth flow fix)

## Test plan
- [ ] Visit `https://hbr.alumicoin.cloud/` with expired session cookie — should show standalone calculator without redirect loop
- [ ] Visit `/standalone/tradeoff` — progress bars should render and update without CSP console errors
- [ ] SMART launch flow still redirects authenticated users to `/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)