### PR TITLE
fix: docker healthcheck — replace curl (not in slim image) with python urllib

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ on:
       - 'templates/**'
       - 'static/**'
       - 'regulatory-output/**'
+      - 'Dockerfile'
+      - 'docker-compose*.yml'
   pull_request:
     branches: [ main, PRECISE-HBR ]
     paths:
@@ -19,9 +21,12 @@ on:
       - 'tests/**'
       - 'config/**'
       - 'requirements.txt'
+      - '.github/workflows/test.yml'  # PR-side trigger so workflow edits self-validate
       - 'templates/**'
       - 'static/**'
       - 'regulatory-output/**'
+      - 'Dockerfile'
+      - 'docker-compose*.yml'
 
 env:
   PYTHON_VERSION: '3.11'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,9 @@ services:
     
     # 健康檢查
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/health"]
+      test:
+        - CMD-SHELL
+        - python -c "import urllib.request; urllib.request.urlopen('http://localhost:9000/health', timeout=5).read()"
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary

修補 `smart_fhir_app` 容器 7 週的 unhealthy 假警報——`docker-compose.yml` healthcheck 用 `curl -f http://localhost:9000/health`，但 `python:3.11-slim` base image 不附 `curl`，每次 probe 直接 `exec: curl: executable file not found`，failingStreak 累積到 ~151k。

`/health` endpoint 本身一直回 200（json `{"status":"healthy","version":"1.1.0"}`）— 只有 probe 壞掉，服務功能不受影響。

## 變動

把 healthcheck 換成 image 既有的 Python urllib：

```yaml
healthcheck:
  test:
    - CMD-SHELL
    - python -c "import urllib.request; urllib.request.urlopen('http://localhost:9000/health', timeout=5).read()"
  interval: 30s
  timeout: 10s
  retries: 3
  start_period: 40s
```

YAML block-list 形式避開 inner `'http://...'` 跟 outer YAML 雙引號的衝突；urllib 用 image 本來就有的 stdlib，零新增 dependency / 零 image size 增加。

## Test plan

- [x] VM 已實際 apply + recreate container → `docker inspect smart_fhir_app` 顯示 `Health: healthy`，FailingStreak `0`，第一次 probe `ExitCode: 0`
- [x] `/health` endpoint 仍回 200（curl `http://localhost:9000/`）
- [ ] PR merge 後重 build／redeploy 不會回到舊 broken healthcheck

🤖 Generated with [Claude Code](https://claude.com/claude-code)
